### PR TITLE
[Mellanox] Adjust log level to avoid too many thermal logs

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -220,7 +220,9 @@ class Fan(FanBase):
         """
         status = True
 
-        if self.is_psu_fan and self.get_presence():
+        if self.is_psu_fan:
+            if not self.get_presence():
+                return False
             from .thermal import logger
             try:
                 with open(self.psu_i2c_bus_path, 'r') as f:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -220,7 +220,7 @@ class Fan(FanBase):
         """
         status = True
 
-        if self.is_psu_fan:
+        if self.is_psu_fan and self.get_presence():
             from .thermal import logger
             try:
                 with open(self.psu_i2c_bus_path, 'r') as f:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -122,6 +122,8 @@ class Psu(PsuBase):
         """
         result = 0
         try:
+            if not os.path.exists(filename):
+                return result
             with open(filename, 'r') as fileobj:
                 result = int(fileobj.read().strip())
         except Exception as e:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -495,12 +495,15 @@ class Thermal(ThermalBase):
         We usually disable the algorithm when we want to set a fix speed. E.g, when 
         a fan unit is removed from system, we will set fan speed to 100% and disable 
         the algorithm to avoid it adjust the speed.
+
+        Returns:
+            True if thermal algorithm status changed.
         """
         if not cls.thermal_profile:
             raise Exception("Fail to get thermal profile for this switch")
 
         if not force and cls.thermal_algorithm_status == status:
-            return
+            return False
 
         cls.thermal_algorithm_status = status
         content = "enabled" if status else "disabled"
@@ -521,6 +524,7 @@ class Thermal(ThermalBase):
                 for index in range(count):
                     cls._write_generic_file(join(THERMAL_ZONE_GEARBOX_PATH.format(start + index), THERMAL_ZONE_MODE), content)
                     cls._write_generic_file(join(THERMAL_ZONE_GEARBOX_PATH.format(start + index), THERMAL_ZONE_POLICY), policy)
+        return True
 
     @classmethod
     def check_thermal_zone_temperature(cls):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_actions.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_actions.py
@@ -131,14 +131,17 @@ class ControlThermalAlgoAction(ThermalPolicyActionBase):
         from .thermal import Thermal
         from .thermal_conditions import UpdateCoolingLevelToMinCondition
         from .fan import Fan
-        Thermal.set_thermal_algorithm_status(self.status, False)
-        if self.status:
-            # Check thermal zone temperature, if all thermal zone temperature
-            # back to normal, set it to minimum allowed speed to
-            # save power
-            UpdateCoolingLevelToMinAction.update_cooling_level_to_minimum(thermal_info_dict)
+        status_changed = Thermal.set_thermal_algorithm_status(self.status, False)
 
-        logger.log_info('Changed thermal algorithm status to {}'.format(self.status))
+        # Only update cooling level if thermal algorithm status changed
+        if status_changed:
+            if self.status:
+                # Check thermal zone temperature, if all thermal zone temperature
+                # back to normal, set it to minimum allowed speed to
+                # save power
+                UpdateCoolingLevelToMinAction.update_cooling_level_to_minimum(thermal_info_dict)
+
+            logger.log_info('Changed thermal algorithm status to {}'.format(self.status))
 
 
 class ChangeMinCoolingLevelAction(ThermalPolicyActionBase):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

1. There are logs that will be printed every 1 minutes which is not necessary
2. When PSU is not present, we should not set its fan speed and trigger error logs

**- How I did it**

1. Trigger thermal log if status change
2. Test sysfs file before reading it

**- How to verify it**

Manually verify

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
