### PR TITLE
[Mellanox] Never disable kernel thermal algorithm at real-time

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/thermal_policy.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/thermal_policy.json
@@ -24,10 +24,6 @@
             ],
             "actions": [
                 {
-                    "type": "thermal_control.control",
-                    "status": "false"
-                },
-                {
                     "type": "fan.all.set_speed",
                     "speed": "100"
                 }
@@ -42,10 +38,6 @@
             ],
             "actions": [
                 {
-                    "type": "thermal_control.control",
-                    "status": "false"
-                },
-                {
                     "type": "fan.all.set_speed",
                     "speed": "100"
                 }
@@ -59,10 +51,6 @@
                 }
             ],
             "actions": [
-                {
-                    "type": "thermal_control.control",
-                    "status": "false"
-                },
                 {
                     "type": "fan.all.set_speed",
                     "speed": "100"
@@ -84,8 +72,7 @@
             ],
             "actions": [
                 {
-                    "type": "thermal_control.control",
-                    "status": "true"
+                    "type": "thermal.recover"
                 }
             ]
         }

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_actions.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_actions.py
@@ -86,9 +86,7 @@ class CheckAndSetAllFanSpeedAction(SetAllFanSpeedAction):
             SetAllFanSpeedAction.execute(self, thermal_info_dict)
         
 
-# Hide this action since there is a bug in kernel, enable/disable
-# thermal algorithm will cause kernel dead lock
-#@thermal_json_object('thermal_control.control')
+@thermal_json_object('thermal_control.control')
 class ControlThermalAlgoAction(ThermalPolicyActionBase):
     """
     Action to control the thermal control algorithm

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_actions.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_actions.py
@@ -86,7 +86,9 @@ class CheckAndSetAllFanSpeedAction(SetAllFanSpeedAction):
             SetAllFanSpeedAction.execute(self, thermal_info_dict)
         
 
-@thermal_json_object('thermal_control.control')
+# Hide this action since there is a bug in kernel, enable/disable
+# thermal algorithm will cause kernel dead lock
+#@thermal_json_object('thermal_control.control')
 class ControlThermalAlgoAction(ThermalPolicyActionBase):
     """
     Action to control the thermal control algorithm
@@ -139,6 +141,12 @@ class ControlThermalAlgoAction(ThermalPolicyActionBase):
             UpdateCoolingLevelToMinAction.update_cooling_level_to_minimum(thermal_info_dict)
 
         logger.log_info('Changed thermal algorithm status to {}'.format(self.status))
+
+
+@thermal_json_object('thermal.recover')
+class ThermalRecoverAction(ThermalPolicyActionBase):
+    def execute(self, thermal_info_dict):
+         UpdateCoolingLevelToMinAction.update_cooling_level_to_minimum(thermal_info_dict)
 
 
 class ChangeMinCoolingLevelAction(ThermalPolicyActionBase):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

Since we will reset fan speed vector in user space, it is safe to run kernel algorithm and SONiC thermal control at the same time. So there is no need to enable/disable thermal algorithm at real-time.

**- How I did it**

1. Remove all thermal actions related to start/stop thermal algorithm
2. Add a new action "ThermalRecoverAction" for policy when all fan/PSU are in good state

**- How to verify it**

Manual test and regression.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
