### PR TITLE
[Mellanox] add ASIC temperature support to platform API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -465,4 +465,3 @@ class Chassis(ChassisBase):
         from .thermal_manager import ThermalManager
         return ThermalManager
 
-

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -465,3 +465,37 @@ class Chassis(ChassisBase):
         from .thermal_manager import ThermalManager
         return ThermalManager
 
+    def get_asic_temperature(self):
+        """
+        Retrieves current temperature reading from ASIC sensor
+
+        Returns:
+            A float number of current temperature in Celsius up to nearest thousandth
+            of one degree Celsius, e.g. 30.125 
+        """
+        from . import thermal
+        temperature_file = join(thermal.THERMAL_ZONE_ASIC_PATH, thermal.THERMAL_ZONE_TEMPERATURE)
+        value_str = thermal.Thermal._read_generic_file(temperature_file, 0)
+        if value_str is None:
+            return None
+
+        value_float = float(value_str)
+        return value_float / 1000.0
+            
+    def get_asic_temperature_threshold(self):
+        """
+        Retrieves the high threshold temperature of ASIC
+
+        Returns:
+            A float number, the high threshold temperature of ASIC in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        from . import thermal
+        threshold_file = join(thermal.THERMAL_ZONE_ASIC_PATH, thermal.THERMAL_ZONE_HIGH_TEMPERATURE)
+        value_str = thermal.Thermal._read_generic_file(threshold_file, 0)
+        if value_str is None:
+            return None
+
+        value_float = float(value_str)
+        return value_float / 1000.0
+

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -465,37 +465,4 @@ class Chassis(ChassisBase):
         from .thermal_manager import ThermalManager
         return ThermalManager
 
-    def get_asic_temperature(self):
-        """
-        Retrieves current temperature reading from ASIC sensor
-
-        Returns:
-            A float number of current temperature in Celsius up to nearest thousandth
-            of one degree Celsius, e.g. 30.125 
-        """
-        from . import thermal
-        temperature_file = join(thermal.THERMAL_ZONE_ASIC_PATH, thermal.THERMAL_ZONE_TEMPERATURE)
-        value_str = thermal.Thermal._read_generic_file(temperature_file, 0)
-        if value_str is None:
-            return None
-
-        value_float = float(value_str)
-        return value_float / 1000.0
-            
-    def get_asic_temperature_threshold(self):
-        """
-        Retrieves the high threshold temperature of ASIC
-
-        Returns:
-            A float number, the high threshold temperature of ASIC in Celsius
-            up to nearest thousandth of one degree Celsius, e.g. 30.125
-        """
-        from . import thermal
-        threshold_file = join(thermal.THERMAL_ZONE_ASIC_PATH, thermal.THERMAL_ZONE_HOT_TEMPERATURE)
-        value_str = thermal.Thermal._read_generic_file(threshold_file, 0)
-        if value_str is None:
-            return None
-
-        value_float = float(value_str)
-        return value_float / 1000.0
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -491,7 +491,7 @@ class Chassis(ChassisBase):
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
         from . import thermal
-        threshold_file = join(thermal.THERMAL_ZONE_ASIC_PATH, thermal.THERMAL_ZONE_HIGH_TEMPERATURE)
+        threshold_file = join(thermal.THERMAL_ZONE_ASIC_PATH, thermal.THERMAL_ZONE_HOT_TEMPERATURE)
         value_str = thermal.Thermal._read_generic_file(threshold_file, 0)
         if value_str is None:
             return None

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -48,7 +48,7 @@ THERMAL_ZONE_GEARBOX_PATH = "/var/run/hw-management/thermal/mlxsw-gearbox{}/"
 THERMAL_ZONE_MODE = "thermal_zone_mode"
 THERMAL_ZONE_POLICY = "thermal_zone_policy"
 THERMAL_ZONE_TEMPERATURE = "thermal_zone_temp"
-THERMAL_ZONE_HIGH_TEMPERATURE = "temp_trip_high"
+THERMAL_ZONE_HOT_TEMPERATURE = "temp_trip_hot"
 THERMAL_ZONE_NORMAL_TEMPERATURE = "temp_trip_norm"
 
 MODULE_TEMPERATURE_FAULT_PATH = "/var/run/hw-management/thermal/module{}_temp_fault"

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -48,10 +48,15 @@ THERMAL_ZONE_GEARBOX_PATH = "/var/run/hw-management/thermal/mlxsw-gearbox{}/"
 THERMAL_ZONE_MODE = "thermal_zone_mode"
 THERMAL_ZONE_POLICY = "thermal_zone_policy"
 THERMAL_ZONE_TEMPERATURE = "thermal_zone_temp"
-THERMAL_ZONE_HOT_TEMPERATURE = "temp_trip_hot"
 THERMAL_ZONE_NORMAL_TEMPERATURE = "temp_trip_norm"
 
 MODULE_TEMPERATURE_FAULT_PATH = "/var/run/hw-management/thermal/module{}_temp_fault"
+
+thermal_api_handler_asic = {
+    THERMAL_API_GET_TEMPERATURE: 'asic',
+    THERMAL_API_GET_HIGH_THRESHOLD: 'mlxsw/temp_trip_hot',
+    THERMAL_API_GET_HIGH_CRITICAL_THRESHOLD: 'mlxsw/temp_trip_crit'
+}
 
 thermal_api_handler_cpu_core = {
     THERMAL_API_GET_TEMPERATURE:"cpu_core{}",
@@ -79,14 +84,14 @@ thermal_api_handler_gearbox = {
     THERMAL_API_GET_HIGH_CRITICAL_THRESHOLD:None
 }
 thermal_ambient_apis = {
-    THERMAL_DEV_ASIC_AMBIENT : "asic",
+    THERMAL_DEV_ASIC_AMBIENT : thermal_api_handler_asic,
     THERMAL_DEV_PORT_AMBIENT : "port_amb",
     THERMAL_DEV_FAN_AMBIENT : "fan_amb",
     THERMAL_DEV_COMEX_AMBIENT : "comex_amb",
     THERMAL_DEV_BOARD_AMBIENT : "board_amb"
 }
 thermal_ambient_name = {
-    THERMAL_DEV_ASIC_AMBIENT : "Ambient ASIC Temp",
+    THERMAL_DEV_ASIC_AMBIENT : 'ASIC',
     THERMAL_DEV_PORT_AMBIENT : "Ambient Port Side Temp",
     THERMAL_DEV_FAN_AMBIENT : "Ambient Fan Side Temp",
     THERMAL_DEV_COMEX_AMBIENT : "Ambient COMEX Temp",
@@ -384,8 +389,14 @@ class Thermal(ThermalBase):
 
     def _get_file_from_api(self, api_name):
         if self.category == THERMAL_DEV_CATEGORY_AMBIENT:
-            if api_name == THERMAL_API_GET_TEMPERATURE:
-                filename = thermal_ambient_apis[self.index]
+            handler = thermal_ambient_apis[self.index]
+            if isinstance(handler, str):
+                if api_name == THERMAL_API_GET_TEMPERATURE:
+                    filename = thermal_ambient_apis[self.index]
+                else:
+                    return None
+            elif isinstance(handler, dict):
+                filename = handler[api_name]
             else:
                 return None
         else:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -48,6 +48,7 @@ THERMAL_ZONE_GEARBOX_PATH = "/var/run/hw-management/thermal/mlxsw-gearbox{}/"
 THERMAL_ZONE_MODE = "thermal_zone_mode"
 THERMAL_ZONE_POLICY = "thermal_zone_policy"
 THERMAL_ZONE_TEMPERATURE = "thermal_zone_temp"
+THERMAL_ZONE_HIGH_TEMPERATURE = "temp_trip_high"
 THERMAL_ZONE_NORMAL_TEMPERATURE = "temp_trip_norm"
 
 MODULE_TEMPERATURE_FAULT_PATH = "/var/run/hw-management/thermal/module{}_temp_fault"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

System health feature requires to read ASIC temperature and threshold from platform API

**- How I did it**

Implement Chassis.get_asic_temperature and Chassis.get_asic_temperature_threshold by getting value from system fs.

**- How to verify it**

Manual test on SN2700.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
