### PR TITLE
[daemon_base] Support loglevel to daemon_base.Logger

### DIFF
--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -43,42 +43,50 @@ def db_connect(db_name):
 #
 
 class Logger(object):
-    def __init__(self, syslog_identifier = None):
+
+    priority_string_dict = {
+        'ERROR': syslog.LOG_ERR,
+        'WARN': syslog.LOG_WARNING,
+        'NOTICE': syslog.LOG_NOTICE,
+        'INFO': syslog.LOG_INFO,
+        'DEBUG': syslog.LOG_DEBUG,
+    }
+
+    def __init__(self, syslog_identifier = None, log_level = 'NOTICE'):
         self.syslog = syslog
         if syslog_identifier is None:
             self.syslog.openlog()
         else:
             self.syslog.openlog(ident=syslog_identifier, logoption=self.syslog.LOG_NDELAY, facility=self.syslog.LOG_DAEMON)
 
+        self.set_level(log_level)
+
     def __del__(self):
         self.syslog.closelog()
 
-    def log_error(self, msg, also_print_to_console=False):
-        self.syslog.syslog(self.syslog.LOG_ERR, msg)
+    def set_level(self, log_level):
+        self.log_level = Logger.priority_string_dict.get(log_level, syslog.LOG_NOTICE)
 
-        if also_print_to_console:
-            print msg
+    def log_error(self, msg, also_print_to_console=False):
+        self.log(msg, also_print_to_console, syslog.LOG_ERR)
 
     def log_warning(self, msg, also_print_to_console=False):
-        self.syslog.syslog(self.syslog.LOG_WARNING, msg)
-
-        if also_print_to_console:
-            print msg
+        self.log(msg, also_print_to_console, syslog.LOG_WARNING)
 
     def log_notice(self, msg, also_print_to_console=False):
-        self.syslog.syslog(self.syslog.LOG_NOTICE, msg)
-
-        if also_print_to_console:
-            print msg
+        self.log(msg, also_print_to_console, syslog.LOG_NOTICE)
 
     def log_info(self, msg, also_print_to_console=False):
-        self.syslog.syslog(self.syslog.LOG_INFO, msg)
-
-        if also_print_to_console:
-            print msg
+        self.log(msg, also_print_to_console, syslog.LOG_INFO)
 
     def log_debug(self, msg, also_print_to_console=False):
-        self.syslog.syslog(self.syslog.LOG_DEBUG, msg)
+        self.log(msg, also_print_to_console, syslog.LOG_DEBUG)
+
+    def log(self, msg, also_print_to_console, log_level):
+        if self.log_level < log_level:
+            return
+
+        self.syslog.syslog(log_level, msg)
 
         if also_print_to_console:
             print msg


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**

Most daemons use daemon_base.Logger as logger class. However, daemon_base.Logger does not support filter logs by log level and it prints a lot DEBUG logs to syslog.

**- How I did it**

1. Add a minimum log level to Logger class
2. Allow daemons to change the minimum log level on fly

**- How to verify it**

Manaul test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
