### PR TITLE
Fix issue: restart thermalctld too quick cause supervisord never restart it again

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -124,7 +124,7 @@ autostart=false
 autorestart=unexpected
 stdout_logfile=syslog
 stderr_logfile=syslog
-startsecs=10
+startsecs=0
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 {% endif %}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Found error logs in syslog:

```
Oct 10 12:41:09.148655 arc-switch1029 INFO pmon#supervisord 2020-10-10 12:41:07,689 INFO gave up: thermalctld entered FATAL state, too many start retries too quickly
```

The issue is related to the "startsecs" configuration of thermalctld in /etc/supervisor/conf.d/supervisord.conf. The current configuration setting the "startsecs" to 10, which means that it require thermalctld process running at least 10 seconds or supervisord will not restart it after it exiting even if the exit code is expected. 

See the official document for "startsecs" at http://supervisord.org/configuration.html:

```
startsecs

The total number of seconds which the program needs to stay running after a startup to consider the start successful. If the program does not stay up for this many seconds after it has started, even if it exits with an “expected” exit code (see exitcodes), the startup will be considered a failure. Set to 0 to indicate that the program needn’t stay running for any particular amount of time.
```

**- How I did it**

The fix is to change the "startsecs" configuration from 10 to 0

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [x] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
