### PR TITLE
[Mellanox] Support max/min speed for PSU fan

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -14,7 +14,7 @@ import subprocess
 try:
     from sonic_platform_base.fan_base import FanBase
     from .led import FanLed, ComponentFaultyIndicator
-    from .util import read_int_from_file, read_str_from_file, write_file
+    from .utils import read_int_from_file, read_str_from_file, write_file
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -162,8 +162,12 @@ class Fan(FanBase):
             int: percentage of the max fan speed
         """
         if self.is_psu_fan:
-            # Not like system fan, psu fan speed can not be modified, so target speed is N/A 
-            return self.get_speed()
+            try:
+                # Get PSU fan target speed according to current system cooling level
+                cooling_level = self.get_cooling_level()
+                return self.PSU_FAN_SPEED[cooling_level]
+            except Exception:
+                return self.get_speed()
 
         pwm = read_int_from_file(os.path.join(FAN_PATH, self.fan_speed_set_path))
         return int(round(pwm*100.0/PWM_MAX))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -165,7 +165,7 @@ class Fan(FanBase):
             try:
                 # Get PSU fan target speed according to current system cooling level
                 cooling_level = self.get_cooling_level()
-                return self.PSU_FAN_SPEED[cooling_level]
+                return int(self.PSU_FAN_SPEED[cooling_level], 16)
             except Exception:
                 return self.get_speed()
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -14,6 +14,7 @@ import subprocess
 try:
     from sonic_platform_base.fan_base import FanBase
     from .led import FanLed, ComponentFaultyIndicator
+    from .util import read_int_from_file, read_str_from_file, write_file
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -52,17 +53,18 @@ class Fan(FanBase):
         else:
             self.led = FanLed(self.index)
 
-        self.fan_min_speed_path = "fan{}_min".format(self.index)
         if not self.is_psu_fan:
             self.fan_speed_get_path = "fan{}_speed_get".format(self.index)
             self.fan_speed_set_path = "fan{}_speed_set".format(self.index)
-            self.fan_max_speed_path = "fan{}_max".format(self.index)
+            self.fan_max_speed_path = os.path.join(FAN_PATH, "fan{}_max".format(self.index))
+            self.fan_min_speed_path = os.path.join(FAN_PATH, "fan{}_min".format(self.index))
             self._name = "fan{}".format(self.index)
         else:
             self.fan_speed_get_path = "psu{}_fan1_speed_get".format(self.index)
             self.fan_presence_path = "psu{}_fan1_speed_get".format(self.index)
             self._name = 'psu_{}_fan_{}'.format(self.index, 1)
-            self.fan_max_speed_path = None
+            self.fan_max_speed_path = os.path.join(CONFIG_PATH, "psu_fan_max")
+            self.fan_min_speed_path = os.path.join(CONFIG_PATH, "psu_fan_min")
             self.psu_i2c_bus_path = os.path.join(CONFIG_PATH, 'psu{0}_i2c_bus'.format(self.index))
             self.psu_i2c_addr_path = os.path.join(CONFIG_PATH, 'psu{0}_i2c_addr'.format(self.index))
             self.psu_i2c_command_path = os.path.join(CONFIG_PATH, 'fan_command')
@@ -109,11 +111,7 @@ class Fan(FanBase):
         if self.is_psu_fan:
             status = 0
         else:
-            try:
-                with open(os.path.join(FAN_PATH, self.fan_status_path), 'r') as fault_status:
-                    status = int(fault_status.read().strip())
-            except (ValueError, IOError):
-                status = 1
+            status = read_int_from_file(os.path.join(FAN_PATH, self.fan_status_path), 1)
 
         return status == 0
 
@@ -135,29 +133,6 @@ class Fan(FanBase):
         else:
             return self.fan_drawer.get_presence()
 
-
-    def _get_min_speed_in_rpm(self):
-        speed = 0
-        try:
-            with open(os.path.join(FAN_PATH, self.fan_min_speed_path), 'r') as min_fan_speed:
-                speed = int(min_fan_speed.read())
-        except (ValueError, IOError):
-            speed = 0
-        
-        return speed
-
-
-    def _get_max_speed_in_rpm(self):
-        speed = 0
-        try:
-            with open(os.path.join(FAN_PATH, self.fan_max_speed_path), 'r') as max_fan_speed:
-                speed = int(max_fan_speed.read().strip())
-        except (ValueError, IOError):
-            speed = 0
-        
-        return speed
-
-
     def get_speed(self):
         """
         Retrieves the speed of fan
@@ -166,17 +141,12 @@ class Fan(FanBase):
             int: percentage of the max fan speed
         """
         speed = 0
-        try:
-            with open(os.path.join(FAN_PATH, self.fan_speed_get_path), 'r') as fan_curr_speed:
-                speed_in_rpm = int(fan_curr_speed.read().strip())
-        except (ValueError, IOError):
-            speed_in_rpm = 0
+        speed_in_rpm = read_int_from_file(os.path.join(FAN_PATH, self.fan_speed_get_path))
 
-        if self.fan_max_speed_path is None:
-            # in case of max speed unsupported, we just return speed in unit of RPM.
+        max_speed_in_rpm = read_int_from_file(self.fan_max_speed_path)
+        if max_speed_in_rpm == 0:
             return speed_in_rpm
 
-        max_speed_in_rpm = self._get_max_speed_in_rpm()
         speed = 100*speed_in_rpm/max_speed_in_rpm
         if speed > 100:
             speed = 100
@@ -195,15 +165,8 @@ class Fan(FanBase):
             # Not like system fan, psu fan speed can not be modified, so target speed is N/A 
             return self.get_speed()
 
-        try:
-            with open(os.path.join(FAN_PATH, self.fan_speed_set_path), 'r') as fan_pwm:
-                pwm = int(fan_pwm.read().strip())
-        except (ValueError, IOError):
-            pwm = 0
-        
-        speed = int(round(pwm*100.0/PWM_MAX))
-        
-        return speed
+        pwm = read_int_from_file(os.path.join(FAN_PATH, self.fan_speed_set_path))
+        return int(round(pwm*100.0/PWM_MAX))
 
 
     def set_speed(self, speed):
@@ -224,12 +187,9 @@ class Fan(FanBase):
                 return False
             from .thermal import logger
             try:
-                with open(self.psu_i2c_bus_path, 'r') as f:
-                    bus = f.read().strip()
-                with open(self.psu_i2c_addr_path, 'r') as f:
-                    addr = f.read().strip()
-                with open(self.psu_i2c_command_path, 'r') as f:
-                    command = f.read().strip()
+                bus = read_str_from_file(self.psu_i2c_bus_path, raise_exception=True)
+                addr = read_str_from_file(self.psu_i2c_addr_path, raise_exception=True)
+                command = read_str_from_file(self.psu_i2c_command_path, raise_exception=True)
                 speed = Fan.PSU_FAN_SPEED[int(speed / 10)]
                 command = "i2cset -f -y {0} {1} {2} {3} wp".format(bus, addr, command, speed)
                 subprocess.check_call(command, shell = True)
@@ -248,8 +208,7 @@ class Fan(FanBase):
                 speed = self.min_cooling_level * 10
             self.set_cooling_level(cooling_level, cooling_level)
             pwm = int(round(PWM_MAX*speed/100.0))
-            with open(os.path.join(FAN_PATH, self.fan_speed_set_path), 'w') as fan_pwm:
-                fan_pwm.write(str(pwm))
+            write_file(os.path.join(FAN_PATH, self.fan_speed_set_path), pwm, raise_exception=True)
         except (ValueError, IOError):
             status = False
 
@@ -311,21 +270,17 @@ class Fan(FanBase):
             # Reset FAN cooling level vector. According to low level team,
             # if we need set cooling level to X, we need first write a (10+X) 
             # to cooling_cur_state file to reset the cooling level vector.
-            with open(COOLING_STATE_PATH, 'w') as cooling_state:
-                cooling_state.write(str(level + 10))
+            write_file(COOLING_STATE_PATH, level + 10, raise_exception=True)
 
             # We need set cooling level after resetting the cooling level vector 
-            with open(COOLING_STATE_PATH, 'w') as cooling_state:
-                cooling_state.write(str(cur_state))
+            write_file(COOLING_STATE_PATH, cur_state, raise_exception=True)
         except (ValueError, IOError) as e:
             raise RuntimeError("Failed to set cooling level - {}".format(e))
 
     @classmethod
     def get_cooling_level(cls):
         try:
-            with open(COOLING_STATE_PATH, 'r') as cooling_state:
-                cooling_level = int(cooling_state.read().strip())
-                return cooling_level
+            return read_int_from_file(COOLING_STATE_PATH, raise_exception=True)
         except (ValueError, IOError) as e:
             raise RuntimeError("Failed to get cooling level - {}".format(e))
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,0 +1,57 @@
+def read_str_from_file(file_path, default='', raise_exception=False):
+    """
+    Read string content from file
+    :param file_path: File path
+    :param default: Default return value if any exception occur
+    :param raise_exception: Raise exception to caller if True else just return default value
+    :return: String content of the file
+    """
+    try:
+        with open(file_path, 'r') as f:
+            value = f.read().strip()
+    except (ValueError, IOError) as e:
+        if not raise_exception:
+            value = default
+        else:
+            raise e
+
+    return value
+
+
+def read_int_from_file(file_path, default=0, raise_exception=False):
+    """
+    Read content from file and cast it to integer
+    :param file_path: File path
+    :param default: Default return value if any exception occur
+    :param raise_exception: Raise exception to caller if True else just return default value
+    :return: Integer value of the file content
+    """
+    try:
+        with open(file_path, 'r') as f:
+            value = int(f.read().strip())
+    except (ValueError, IOError) as e:
+        if not raise_exception:
+            value = default
+        else:
+            raise e
+
+    return value
+
+
+def write_file(file_path, content, raise_exception=False):
+    """
+    Write the given value to a file
+    :param file_path: File path
+    :param content: Value to write to the file
+    :param raise_exception: Raise exception to caller if True
+    :return: True if write success else False
+    """
+    try:
+        with open(file_path, 'w') as f:
+            f.write(str(content))
+    except (ValueError, IOError) as e:
+        if not raise_exception:
+            return False
+        else:
+            raise e
+    return True


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

As new hw-mgmt expose the sysfs for PSU fan max speed, we need support max/min speed for PSU fan in mellanox platform API.

**- How I did it**

Read the max fan speed from sysfs.

**- How to verify it**

Manual test and run existing regression.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
