### PR TITLE
[Mellanox] Remove eeprom cache file when first time init eeprom object

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -63,19 +63,19 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
         self._eeprom_loaded = True
 
     def _load_eeprom(self):
+        cache_file = os.path.join(CACHE_ROOT, CACHE_FILE)
         if not os.path.exists(CACHE_ROOT):
             try:
                 os.makedirs(CACHE_ROOT)
             except:
                 pass
-
-        cache_file = os.path.join(CACHE_ROOT, CACHE_FILE)
-        try:
-            # Make sure first time always read eeprom data from hardware
-            if os.path.exists(cache_file):
-                os.remove(cache_file)
-        except Exception as e:
-            logger.log_error('Failed to remove cache file {} - {}'.format(cache_file, repr(e)))
+        else:
+            try:
+                # Make sure first time always read eeprom data from hardware
+                if os.path.exists(cache_file):
+                    os.remove(cache_file)
+            except Exception as e:
+                logger.log_error('Failed to remove cache file {} - {}'.format(cache_file, repr(e)))
 
         try:
             self.set_cache_name(cache_file)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/eeprom.py
@@ -13,10 +13,14 @@ import sys
 import re
 from cStringIO import StringIO
 
+from sonic_py_common.logger import Logger
+
 try:
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
+
+logger = Logger()
 
 #
 # CACHE_XXX stuffs are supposted to be moved to the base classes
@@ -65,8 +69,16 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
             except:
                 pass
 
+        cache_file = os.path.join(CACHE_ROOT, CACHE_FILE)
         try:
-            self.set_cache_name(os.path.join(CACHE_ROOT, CACHE_FILE))
+            # Make sure first time always read eeprom data from hardware
+            if os.path.exists(cache_file):
+                os.remove(cache_file)
+        except Exception as e:
+            logger.log_error('Failed to remove cache file {} - {}'.format(cache_file, repr(e)))
+
+        try:
+            self.set_cache_name(cache_file)
         except:
             pass
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

EEPROM cache file is not refreshed after install a new ONIE version even if the eeprom data is updated. The current Eeprom class always try to read from the cache file when the file exists. The PR is aimed to fix it. 

**- How I did it**

When eeprom object init, always remove the cache file and read eeprom data from hardware.

**- How to verify it**

Run platform related regression test cases

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
