### PR TITLE
[Mellanox] Fix dynamic minimum fan table issue caused by python3

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_conditions.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_conditions.py
@@ -85,7 +85,7 @@ class MinCoolingLevelChangeCondition(ThermalPolicyConditionBase):
 
         trust_state = Thermal.check_module_temperature_trustable()
         temperature = Thermal.get_min_amb_temperature()
-        temperature = temperature / 1000
+        temperature = int(temperature / 1000)
 
         change_cooling_level = False
         if trust_state != MinCoolingLevelChangeCondition.trust_state:

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_policy.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_policy.py
@@ -482,7 +482,7 @@ def test_dynamic_minimum_policy(thermal_manager):
     condition = policy.conditions[MinCoolingLevelChangeCondition]
     action = policy.actions[ChangeMinCoolingLevelAction]
     Thermal.check_module_temperature_trustable = MagicMock(return_value='trust')
-    Thermal.get_min_amb_temperature = MagicMock(return_value=35000)
+    Thermal.get_min_amb_temperature = MagicMock(return_value=35001)
     assert condition.is_match(None)
     assert MinCoolingLevelChangeCondition.trust_state == 'trust'
     assert MinCoolingLevelChangeCondition.temperature == 35
@@ -492,7 +492,7 @@ def test_dynamic_minimum_policy(thermal_manager):
     assert condition.is_match(None)
     assert MinCoolingLevelChangeCondition.trust_state == 'untrust'
 
-    Thermal.get_min_amb_temperature = MagicMock(return_value=25000)
+    Thermal.get_min_amb_temperature = MagicMock(return_value=25999)
     assert condition.is_match(None)
     assert MinCoolingLevelChangeCondition.temperature == 25
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

After migrating to python3, the operator '/' always get a float result, but it gets integer result in python2. Need fix this in thermal_conditions.

**- How I did it**

1. cast float value to int
2. change the unit test case to cover this situation

**- How to verify it**

Manually test and regression test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
