### PR TITLE
[Mellanox] Fix issue: should not initialize led color in __init__ funcation as platform API will be called by multiple daemons

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/led.py
@@ -207,8 +207,6 @@ class FanLed(Led):
             self._orange_led_path = os.path.join(Led.LED_PATH, "led_fan_orange")
             self._led_cap_path = os.path.join(Led.LED_PATH, "led_fan_capability")
 
-        self.set_status(Led.STATUS_LED_COLOR_GREEN)
-
     def get_green_led_path(self):
         return self._green_led_path
 
@@ -234,8 +232,6 @@ class PsuLed(Led):
             self._red_led_path = os.path.join(Led.LED_PATH, "led_psu_red")
             self._orange_led_path = os.path.join(Led.LED_PATH, "led_psu_orange")
             self._led_cap_path = os.path.join(Led.LED_PATH, "led_psu_capability")
-            
-        self.set_status(Led.STATUS_LED_COLOR_GREEN)
 
     def get_green_led_path(self):
         return self._green_led_path


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The existing Fan led and Psu led object initialize itself to green color in __init__ method. However, there are multiple daemons calls sonic platform API and there could be a case that:

1. A PSU is removed from system
2. Reboot switch
3. psud detects that 1 PSU is missing and set PSU led to red
4. other daemon just start up and call sonic platform API, the API set PSU led to green by call PsuLed.__init__

This PR is a partial fix for the issue. As we also need guarantee that the led is initialized with a correct value. I checked existing psud and thermalctld code. psud always initialize the PSU led color on boot up, thermalcltd need some changes to initialize led color on the first run

#### How I did it

Remove the led color initialization code from FanLed.__init__ and PsuLed.__init__

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

