### PR TITLE
[Mellanox] clear fan from chassis._fan_list

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -140,7 +140,6 @@ class Chassis(ChassisBase):
                 fan = Fan(fan_index, drawer, index + 1)
                 fan_index += 1
                 drawer._fan_list.append(fan)
-                self._fan_list.append(fan)
 
 
     def initialize_single_sfp(self, index):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_infos.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_infos.py
@@ -24,26 +24,27 @@ class FanInfo(ThermalPolicyInfoBase):
         :return:
         """
         self._status_changed = False
-        for fan in chassis.get_all_fans():
-            presence = fan.get_presence()
-            status = fan.get_status()
-            if presence and fan not in self._presence_fans:
-                self._presence_fans.add(fan)
-                self._status_changed = True
-                if fan in self._absence_fans:
-                    self._absence_fans.remove(fan)
-            elif not presence and fan not in self._absence_fans:
-                self._absence_fans.add(fan)
-                self._status_changed = True
-                if fan in self._presence_fans:
-                    self._presence_fans.remove(fan)
+        for fan_drawer in chassis.get_all_fan_drawers():
+            for fan in fan_drawer.get_all_fans():
+                presence = fan.get_presence()
+                status = fan.get_status()
+                if presence and fan not in self._presence_fans:
+                    self._presence_fans.add(fan)
+                    self._status_changed = True
+                    if fan in self._absence_fans:
+                        self._absence_fans.remove(fan)
+                elif not presence and fan not in self._absence_fans:
+                    self._absence_fans.add(fan)
+                    self._status_changed = True
+                    if fan in self._presence_fans:
+                        self._presence_fans.remove(fan)
 
-            if not status and fan not in self._fault_fans:
-                self._fault_fans.add(fan)
-                self._status_changed = True
-            elif status and fan in self._fault_fans:
-                self._fault_fans.remove(fan)
-                self._status_changed = True
+                if not status and fan not in self._fault_fans:
+                    self._fault_fans.add(fan)
+                    self._status_changed = True
+                elif status and fan in self._fault_fans:
+                    self._fault_fans.remove(fan)
+                    self._status_changed = True
                     
 
     def get_absence_fans(self):

--- a/platform/mellanox/mlnx-platform-api/tests/mock_platform.py
+++ b/platform/mellanox/mlnx-platform-api/tests/mock_platform.py
@@ -36,16 +36,28 @@ class MockPsu:
         return []
 
 
+class MockFanDrawer:
+    def __init__(self):
+        self.fan_list = []
+
+    def get_all_fans(self):
+        return self.fan_list
+
+
 class MockChassis:
     def __init__(self):
         self.fan_list = []
         self.psu_list = []
+        self.fan_drawer_list = []
 
     def get_all_psus(self):
         return self.psu_list
 
     def get_all_fans(self):
         return self.fan_list
+
+    def get_all_fan_drawers(self):
+        return self.fan_drawer_list
 
     def get_thermal_manager(self):
         from sonic_platform.thermal_manager import ThermalManager
@@ -54,7 +66,9 @@ class MockChassis:
     def make_fan_absence(self):
         fan = MockFan()
         fan.presence = False
-        self.fan_list.append(fan)
+        fan_drawer = MockFanDrawer()
+        self.fan_drawer_list.append(fan_drawer)
+        fan_drawer.fan_list.append(fan)
 
     def make_psu_absence(self):
         psu = MockPsu()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

According to thermalctld hld, each fan must belong to a fan drawer, if the fan drawer does not physically exist, put fan into a virtual fan drawer. This PR is to clear fan from chassis._fan_list

#### How I did it

1. Don't put fan to chassis._fan_list
2. Always query fan from fan_drawer

#### How to verify it

Adjust unit test to verify the change

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

