### PR TITLE
[Mellanox] Read EEPROM data from DB if possible

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,3 +1,4 @@
+import functools
 import subprocess
 
 # flags to indicate whether this process is running in docker or host
@@ -89,3 +90,15 @@ def is_host():
         pass
 
     return _is_host
+
+
+def default_return(return_value):
+    def wrapper(method):
+        @functools.wraps(method)
+        def _impl(*args, **kwargs):
+            try:
+                return method(*args, **kwargs)
+            except:
+                return return_value
+        return _impl
+    return wrapper


### PR DESCRIPTION
Depends on https://github.com/Junchao-Mellanox/sonic-platform-common/pull/12
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Remove EEPROM cache file and use DB instead

#### How I did it

1. Read EEPROM data from DB if possible
2. If data is not ready in DB, read from hardware using a visitor pattern

#### How to verify it

Manual test and regression

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

