### PR TITLE
[Yang model] Allow user to set none value for interface type 

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-types.yang
+++ b/src/sonic-yang-models/yang-models/sonic-types.yang
@@ -129,7 +129,7 @@ module sonic-types {
             enum UDP;
         }
     }
-    
+
     typedef interface_type {
         type enumeration {
             enum CR;
@@ -151,6 +151,7 @@ module sonic-types {
             enum XAUI;
             enum XFI;
             enum XGMII;
+            enum none;
         }
     }
 
@@ -167,7 +168,7 @@ module sonic-types {
     }
     typedef meter_type {
         type enumeration {
-            enum packets; 
+            enum packets;
             enum bytes;
         }
     }
@@ -183,5 +184,5 @@ module sonic-types {
             enum deny;
             enum transit;
         }
-    }        
+    }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Allow user to set none value for interface type

**Why I did it**

Say user has speed=50G, interface_type=CR2, and user wants to change it to 10G and CR. Currently, there is no CLI can support it, because:

1. If you change the interface type to CR first, SAI will get 50G and CR, SAI will report error because not supported
2. If you change the speed to 10G first, SAI will get 10G and CR2, also not supported

The only way for now is to manually change the CONFIG_DB and do a config reload, this is not user friendly.

This PR allow user to set none value to interface type. So there is a way to achieve the goal via CLI:

1. config interface type XXX none
2. config interface speed XXX 10000
3. config interface type XXX CR

**How I verified it**

Manual test

**Details if related**
