### PR TITLE
[Mellanox] Use hw-mgmt thermal control service

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/thermal_policy.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/thermal_policy.json
@@ -1,80 +1,8 @@
 {   
     "thermal_control_algorithm": {
-        "run_at_boot_up": "true",
-        "fan_speed_when_suspend": "60"
     },
     "info_types": [
-        {
-            "type": "fan_info"
-        },
-        {
-            "type": "psu_info"
-        },
-        {
-            "type": "chassis_info"
-        }
     ],
     "policies": [
-        {
-            "name": "any fan absence",
-            "conditions": [
-                {
-                    "type": "fan.any.absence"
-                }
-            ],
-            "actions": [
-                {
-                    "type": "fan.all.set_speed",
-                    "speed": "100"
-                }
-            ]
-        },
-        {
-            "name": "any psu absence",
-            "conditions": [
-                {
-                    "type": "psu.any.absence"
-                }
-            ],
-            "actions": [
-                {
-                    "type": "fan.all.set_speed",
-                    "speed": "100"
-                }
-            ]
-        },
-        {
-            "name": "any fan broken",
-            "conditions": [
-                {
-                    "type": "fan.any.fault"
-                }
-            ],
-            "actions": [
-                {
-                    "type": "fan.all.set_speed",
-                    "speed": "100"
-                }
-            ]
-        },
-        {
-            "name": "all fan and psu presence",
-            "conditions": [
-                {
-                    "type": "fan.all.presence"
-                },
-                {
-                    "type": "psu.all.presence"
-                },
-                {
-                    "type": "fan.all.good"
-                }
-            ],
-            "actions": [
-                {
-                    "type": "thermal.recover"
-                }
-            ]
-        }
     ]
 }

--- a/platform/mellanox/hw-management/0003-Enable-hw-mgmt-thermal-control-service.patch
+++ b/platform/mellanox/hw-management/0003-Enable-hw-mgmt-thermal-control-service.patch
@@ -1,0 +1,24 @@
+From e10da522b12daad1ce2770b9bb925060911bceef Mon Sep 17 00:00:00 2001
+From: junchao <junchao@nvidia.com>
+Date: Tue, 8 Feb 2022 14:28:52 +0800
+Subject: [PATCH] Enable hw-mgmt thermal control service
+
+---
+ debian/rules | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/debian/rules b/debian/rules
+index e256dd8..165bd3f 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -29,6 +29,7 @@ override_dh_installinit:
+ 
+ override_dh_systemd_enable:
+ 	dh_systemd_enable --name=hw-management
++	dh_systemd_enable --name=hw-management-tc
+ 
+ override_dh_systemd_start:
+ 	dh_systemd_start --name=hw-management
+-- 
+1.9.1
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Use hw-mgmt thermal control service on Mellanox platform. 

Benefit:

1.  hw-mgmt thermal control works close with kernel
2. hw-mgmt thermal control has no extra dependency while SONiC thermal control depends on PMON
3. hw-mgmt thermal control can work at real time while SONiC thermal control works every 1 minute
4. hw-mgmt thermal control takes effect right after system boot while SONiC thermal control works after PMON is up

Impact:

1. No code change for thermalctld
2. No code change for CLI
3. No code change for platform API
4. No code change for other vendor
5. No impact to thermal/fan data collecting function

#### How I did it

1. Remove thermal policies from thermal control configuration file
2. Enable hw-mgmt thermal control service by default

#### How to verify it

Manual test on 4700

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

