### PR TITLE
Fix issue: psu might use wrong voltage sysfs which causes invalid voltage value

### DIFF
--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -50,6 +50,7 @@ class TestPsu:
         assert psu.get_temperature() is None
         assert psu.get_temperature_high_threshold() is None
 
+    @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
     def test_psu(self):
         psu = Psu(0)
         assert len(psu._fan_list) == 1
@@ -58,6 +59,8 @@ class TestPsu:
             psu.psu_presence: 1,
             psu.psu_oper_status: 1,
             psu.psu_voltage: 10234,
+            psu.psu_voltage_min: 9000,
+            psu.psu_voltage_max: 12000,
             psu.psu_current: 20345,
             psu.psu_power: 30456,
             psu.psu_temp: 40567,
@@ -68,6 +71,7 @@ class TestPsu:
             return mock_sysfs_content[file_path]
 
         utils.read_int_from_file = mock_read_int_from_file
+        utils.read_str_from_file = mock.MagicMock(return_value='min max')
         assert psu.get_presence() is True
         mock_sysfs_content[psu.psu_presence] = 0
         assert psu.get_presence() is False
@@ -84,6 +88,8 @@ class TestPsu:
 
         mock_sysfs_content[psu.psu_oper_status] = 1
         assert psu.get_voltage() == 10.234
+        assert psu.get_voltage_high_threshold() == 12.0
+        assert psu.get_voltage_low_threshold() == 9.0
         assert psu.get_current() == 20.345
         assert psu.get_power() == 0.030456
         assert psu.get_temperature() == 40.567


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

