### PR TITLE
Fix issue: non default counters will be delayed forever

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -10,10 +10,10 @@ DEFAULT_SMOOTH_INTERVAL = '10'
 DEFAULT_ALPHA = '0.18'
 
 
-def enable_counter_group(db, name):
+def enable_counter_group(db, name, enable_by_default=True):
     entry_info = db.get_entry("FLEX_COUNTER_TABLE", name)
 
-    if not entry_info:
+    if (not entry_info) and enable_by_default:
         info = {}
         info['FLEX_COUNTER_STATUS'] = 'enable'
         db.mod_entry("FLEX_COUNTER_TABLE", name, info)
@@ -38,16 +38,15 @@ def enable_rates():
 def enable_counters():
     db = swsssdk.ConfigDBConnector()
     db.connect()
-    enable_counter_group(db, 'PORT')
-    enable_counter_group(db, 'RIF')
-    enable_counter_group(db, 'QUEUE')
-    enable_counter_group(db, 'PFCWD')
-    enable_counter_group(db, 'PG_WATERMARK')
-    enable_counter_group(db, 'PG_DROP')
-    enable_counter_group(db, 'QUEUE_WATERMARK')
-    enable_counter_group(db, 'BUFFER_POOL_WATERMARK')
-    enable_counter_group(db, 'PORT_BUFFER_DROP')
-    enable_counter_group(db, 'ACL')
+    default_enabled_counters = ['PORT', 'RIF', 'QUEUE', 'PFCWD', 'PG_WATERMARK', 'PG_DROP', 
+                                'QUEUE_WATERMARK', 'BUFFER_POOL_WATERMARK', 'PORT_BUFFER_DROP', 'ACL']
+
+    keys = db.get_keys('FLEX_COUNTER_TABLE')
+    for key in keys:
+        if key in default_enabled_counters:
+            enable_counter_group(db, key)
+        else:
+            enable_counter_group(db, key, enable_by_default=False)
     enable_rates()
 
 

--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -10,10 +10,10 @@ DEFAULT_SMOOTH_INTERVAL = '10'
 DEFAULT_ALPHA = '0.18'
 
 
-def enable_counter_group(db, name, enable_by_default=True):
+def enable_counter_group(db, name):
     entry_info = db.get_entry("FLEX_COUNTER_TABLE", name)
 
-    if (not entry_info) and enable_by_default:
+    if not entry_info:
         info = {}
         info['FLEX_COUNTER_STATUS'] = 'enable'
         db.mod_entry("FLEX_COUNTER_TABLE", name, info)
@@ -40,13 +40,16 @@ def enable_counters():
     db.connect()
     default_enabled_counters = ['PORT', 'RIF', 'QUEUE', 'PFCWD', 'PG_WATERMARK', 'PG_DROP', 
                                 'QUEUE_WATERMARK', 'BUFFER_POOL_WATERMARK', 'PORT_BUFFER_DROP', 'ACL']
+    
+    # Enable those default counters
+    for key in default_enabled_counters:
+        enable_counter_group(db, key)
 
+    # Set FLEX_COUNTER_DELAY_STATUS to false for those non-default counters
     keys = db.get_keys('FLEX_COUNTER_TABLE')
     for key in keys:
-        if key in default_enabled_counters:
+        if key not in default_enabled_counters:
             enable_counter_group(db, key)
-        else:
-            enable_counter_group(db, key, enable_by_default=False)
     enable_rates()
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fastboot will delay all counters in CONFIG DB, it replies on enable_counters.py to recover the delayed counters. However, enable_counters.py does not recover those non-default counters.

#### How I did it

For non-default counters, if it is in CONFIG DB, put delay status to false after the waiting.

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

