### PR TITLE
Fix issue: failed to decode Json while there is no hwsku.json

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -111,7 +111,8 @@ class Chassis(ChassisBase):
         self.reboot_cause_initialized = False
 
         # Build the RJ45 port list from platform.json and hwsku.json
-        self.RJ45_port_list = extract_RJ45_ports_index()
+        self._RJ45_port_inited = False
+        self._RJ45_port_list = None
 
         logger.log_info("Chassis loaded successfully")
 
@@ -123,6 +124,13 @@ class Chassis(ChassisBase):
             from .sfp import SFP, deinitialize_sdk_handle
             if SFP.shared_sdk_handle:
                 deinitialize_sdk_handle(SFP.shared_sdk_handle)
+
+    @property
+    def RJ45_port_list(self):
+        if not self._RJ45_port_inited:
+            self._RJ45_port_list = extract_RJ45_ports_index()
+            self._RJ45_port_inited = True
+        return self._RJ45_port_list
 
     ##############################################
     # PSU methods

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -177,12 +177,12 @@ def is_host():
     """
     Test whether current process is running on the host or an docker
     return True for host and False for docker
-    """ 
+    """
     try:
-        proc = subprocess.Popen("docker --version 2>/dev/null", 
-                                stdout=subprocess.PIPE, 
-                                shell=True, 
-                                stderr=subprocess.STDOUT, 
+        proc = subprocess.Popen("docker --version 2>/dev/null",
+                                stdout=subprocess.PIPE,
+                                shell=True,
+                                stderr=subprocess.STDOUT,
                                 universal_newlines=True)
         stdout = proc.communicate()[0]
         proc.wait()
@@ -239,9 +239,13 @@ def load_json_file(filename, log_func=logger.log_error):
 def extract_RJ45_ports_index():
     # Cross check 'platform.json' and 'hwsku.json' to extract the RJ45 port index if exists.
     hwsku_path = device_info.get_path_to_hwsku_dir()
+    hwsku_file = os.path.join(hwsku_path, HWSKU_JSON)
+    if not os.path.exists(hwsku_file):
+        # Platforms having no hwsku.json do not have RJ45 port
+        return None
+
     platform_file = device_info.get_path_to_port_config_file()
     platform_dict = load_json_file(platform_file)['interfaces']
-    hwsku_file = os.path.join(hwsku_path, HWSKU_JSON)
     hwsku_dict = load_json_file(hwsku_file)['interfaces']
     port_name_to_index_map_dict = {}
     RJ45_port_index_list = []

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -113,10 +113,15 @@ class TestUtils:
         @utils.default_return(100, log_func=mock_log)
         def func():
             raise RuntimeError('')
-        
+
         assert func() == 100
         assert mock_log.call_count == 1
 
     def test_run_command(self):
         output = utils.run_command('ls')
         assert output
+
+    @mock.patch('sonic_py_common.device_info.get_path_to_hwsku_dir', mock.MagicMock(return_value='/tmp'))
+    def test_extract_RJ45_ports_index(self):
+        rj45_list = utils.extract_RJ45_ports_index()
+        assert rj45_list is None


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix bug: pmon report error on start up because some SKUs do not have hwsku.json

#### How I did it

If hwsku.json, do not extract RJ45 port information

#### How to verify it

Manual test.
Unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

