### PR TITLE
Fix issue: rsyslog rate limit does not work on version 8.2110.0

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -331,7 +331,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     sysfsutils              \
     squashfs-tools          \
     grub2-common            \
-    rsyslog                 \
     screen                  \
     hping3                  \
     tcptraceroute           \
@@ -355,6 +354,10 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     gpg                     \
     jq                      \
     auditd
+
+# default rsyslog version is 8.2110.0 which has a bug on log rate limit,
+# use backport version 8.2206.0-1~bpo11+1
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install rsyslog=8.2206.0-1~bpo11+1
 
 # Have systemd create the auditd log directory
 sudo mkdir -p ${FILESYSTEM_ROOT}/etc/systemd/system/auditd.service.d

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -48,7 +48,6 @@ RUN apt-get update &&        \
         python3              \
         python3-distutils    \
         python3-pip          \
-        rsyslog              \
         vim-tiny             \
 # Install redis-tools
         redis-tools          \
@@ -64,6 +63,10 @@ RUN apt-get update &&        \
 # for sairedis zmq rpc channel
         libzmq5              \
         libwrap0
+
+# default rsyslog version is 8.2110.0 which has a bug on log rate limit,
+# use backport version 8.2206.0-1~bpo11+1
+RUN apt-get -y install rsyslog=8.2206.0-1~bpo11+1
 
 # Upgrade pip via PyPI and uninstall the Debian version
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The default stable version of rsyslog on bullseye has a bug about rate limit. It causes rate limit not work. The bug has been fixed on backport version 8.2206.0-1~bpo11+1.

Buster has no such issue.

#### How I did it

Upgrade rsyslog from 8.2110.0 to 8.2206.0-1~bpo11+1

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

