### PR TITLE
Fix issue: ERR healthd: Get unit status determine-reboot-cause-'LoadState'

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -273,7 +273,7 @@ class Sysmonitor(ProcessTaskBase):
             
             sysctl_show = self.run_systemctl_show(event)
 
-            load_state = sysctl_show['LoadState']
+            load_state = sysctl_show.get('LoadState')
             if load_state == "loaded":
                 status = sysctl_show['UnitFileState']
                 fail_reason = sysctl_show['Result']


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix issue: ERR healthd: Get unit status determine-reboot-cause-'LoadState'. The error log is only seen on shutdown flow such as fast-reboot/warm-reboot.

 In shutdown flow, 'LoadState' might not be available in `systemctl status` output, using `[]` might cause a `KeyError`.  

#### How I did it

Use `dict.get` instead of `[]`

#### How to verify it

Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

