### PR TITLE
Syncd graceful shutdown should not be ignored

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -104,28 +104,26 @@ function stopplatform1() {
         debug "Stopped pmon service"
     fi
 
-    if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
-        debug "${TYPE} shutdown syncd process ..."
-        /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}
+    debug "${TYPE} shutdown syncd process ..."
+    /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}
 
-        # wait until syncd quits gracefully or force syncd to exit after
-        # waiting for 20 seconds
-        start_in_secs=${SECONDS}
+    # wait until syncd quits gracefully or force syncd to exit after
+    # waiting for 20 seconds
+    start_in_secs=${SECONDS}
+    end_in_secs=${SECONDS}
+    timer_threshold=20
+    while docker top syncd$DEV | grep -q /usr/bin/syncd \
+            && [[ $((end_in_secs - start_in_secs)) -le $timer_threshold ]]; do
+        sleep 0.1
         end_in_secs=${SECONDS}
-        timer_threshold=20
-        while docker top syncd$DEV | grep -q /usr/bin/syncd \
-                && [[ $((end_in_secs - start_in_secs)) -le $timer_threshold ]]; do
-            sleep 0.1
-            end_in_secs=${SECONDS}
-        done
+    done
 
-        if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
-            debug "syncd process in container syncd$DEV did not exit gracefully"
-        fi
-
-        /usr/bin/docker exec -i syncd$DEV /bin/sync
-        debug "Finished ${TYPE} shutdown syncd process ..."
+    if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
+        debug "syncd process in container syncd$DEV did not exit gracefully"
     fi
+
+    /usr/bin/docker exec -i syncd$DEV /bin/sync
+    debug "Finished ${TYPE} shutdown syncd process ..."
 }
 
 function stopplatform2() {


### PR DESCRIPTION
Why I did this?

Due to a limitation in mellanox platform, sonic ignores syncs graceful shutdown in syncd.sh previously. However, ignoring graceful shutdown in syncd.sh also ignores closing other resources such as removing all counters. 
This PR changes syncd shutdown flow for mellanox platform to make sure it execute graceful shutdown flow. There is another PR for sonic-sairedis to make sure mellanox platform does not call remove_switch for cold shutdown.

How I test this?

Running config reload on many platforms and check result.
