### PR TITLE
[Mellanox] add PSU fan direction support

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -145,6 +145,7 @@ class PsuFan(MlnxFan):
         self.psu_i2c_bus_path = os.path.join(CONFIG_PATH, 'psu{0}_i2c_bus'.format(self.index))
         self.psu_i2c_addr_path = os.path.join(CONFIG_PATH, 'psu{0}_i2c_addr'.format(self.index))
         self.psu_i2c_command_path = os.path.join(CONFIG_PATH, 'fan_command')
+        self.psu_fan_dir_path = os.path.join(FAN_PATH, "psu{}_fan_dir".format(self.index))
 
     def get_direction(self):
         """
@@ -165,7 +166,17 @@ class PsuFan(MlnxFan):
                 1 stands for forward, in other words intake
                 0 stands for reverse, in other words exhaust
         """
-        return self.FAN_DIRECTION_NOT_APPLICABLE
+        if not os.path.exists(self.psu_fan_dir_path) or not self.get_presence():
+            return self.FAN_DIRECTION_NOT_APPLICABLE
+
+        fan_dir = utils.read_int_from_file(self.psu_fan_dir_path)
+        if fan_dir == FAN_DIR_VALUE_INTAKE:
+            return FanBase.FAN_DIRECTION_INTAKE
+        elif fan_dir == FAN_DIR_VALUE_EXHAUST:
+            return FanBase.FAN_DIRECTION_EXHAUST
+        else:
+            logger.log_error("Got wrong value {} for PSU fan direction {}".format(fan_dir, self.psu_fan_dir_path))
+            return FanBase.FAN_DIRECTION_NOT_APPLICABLE
 
     def get_status(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -31,6 +31,7 @@ try:
     from .led import ComponentFaultyIndicator
     from . import utils
     from .thermal import Thermal
+    from .fan_drawer import VirtualDrawer
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -45,7 +46,10 @@ CONFIG_PATH = "/var/run/hw-management/config"
 FAN_DIR = "/var/run/hw-management/thermal/fan{}_dir"
 FAN_DIR_VALUE_EXHAUST = 0
 FAN_DIR_VALUE_INTAKE = 1
-
+FAN_DIR_MAPPING = {
+    FAN_DIR_VALUE_EXHAUST: FanBase.FAN_DIRECTION_EXHAUST,
+    FAN_DIR_VALUE_INTAKE: FanBase.FAN_DIRECTION_INTAKE,
+}
 
 class MlnxFan(FanBase):
     def __init__(self, fan_index, position):
@@ -125,6 +129,20 @@ class MlnxFan(FanBase):
         """
         return False
 
+    @classmethod
+    def get_fan_direction(cls, dir_path):
+        try:
+            fan_dir = utils.read_int_from_file(dir_path, raise_exception=True)
+            ret = FAN_DIR_MAPPING.get(fan_dir)
+            if ret is None:
+                logger.log_error(f"Got wrong value {fan_dir} for fan direction {dir_path}")
+                return FanBase.FAN_DIRECTION_NOT_APPLICABLE
+            else:
+                return ret
+        except (ValueError, IOError) as e:
+            logger.log_error(f"Failed to read fan direction from {dir_path} - {e}")
+            return FanBase.FAN_DIRECTION_NOT_APPLICABLE
+
 
 class PsuFan(MlnxFan):
     # PSU fan speed vector
@@ -169,14 +187,7 @@ class PsuFan(MlnxFan):
         if not os.path.exists(self.psu_fan_dir_path) or not self.get_presence():
             return self.FAN_DIRECTION_NOT_APPLICABLE
 
-        fan_dir = utils.read_int_from_file(self.psu_fan_dir_path)
-        if fan_dir == FAN_DIR_VALUE_INTAKE:
-            return FanBase.FAN_DIRECTION_INTAKE
-        elif fan_dir == FAN_DIR_VALUE_EXHAUST:
-            return FanBase.FAN_DIRECTION_EXHAUST
-        else:
-            logger.log_error("Got wrong value {} for PSU fan direction {}".format(fan_dir, self.psu_fan_dir_path))
-            return FanBase.FAN_DIRECTION_NOT_APPLICABLE
+        return MlnxFan.get_fan_direction(self.psu_fan_dir_path)
 
     def get_status(self):
         """
@@ -274,7 +285,10 @@ class Fan(MlnxFan):
                 1 stands for forward, in other words intake
                 0 stands for reverse, in other words exhaust
         """
-        return self.fan_drawer.get_direction()
+        if not isinstance(self.fan_drawer, VirtualDrawer):
+            return self.fan_drawer.get_direction()
+        else:
+            return MlnxFan.get_fan_direction(FAN_DIR.format(self.index))
 
     def get_status(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan_drawer.py
@@ -58,19 +58,8 @@ class MellanoxFanDrawer(FanDrawerBase):
         if not self.get_presence():
             return FanBase.FAN_DIRECTION_NOT_APPLICABLE
         
-        try:
-            from .fan import FAN_DIR, FAN_DIR_VALUE_INTAKE, FAN_DIR_VALUE_EXHAUST
-            fan_dir = utils.read_int_from_file(FAN_DIR.format(self._index), raise_exception=True)
-            if fan_dir == FAN_DIR_VALUE_INTAKE:
-                return FanBase.FAN_DIRECTION_INTAKE
-            elif fan_dir == FAN_DIR_VALUE_EXHAUST:
-                return FanBase.FAN_DIRECTION_EXHAUST
-            else:
-                logger.log_error("Got wrong value {} for fan direction {}".format(fan_dir, self._index))
-                return FanBase.FAN_DIRECTION_NOT_APPLICABLE
-        except (ValueError, IOError) as e:
-            logger.log_error("Failed to read fan direction status to {}".format(repr(e)))
-            return FanBase.FAN_DIRECTION_NOT_APPLICABLE
+        from .fan import FAN_DIR, MlnxFan
+        return MlnxFan.get_fan_direction(FAN_DIR.format(self._index))
 
     def set_status_led(self, color):
         """

--- a/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
@@ -131,6 +131,8 @@ class TestFan:
         assert fan.get_direction() == Fan.FAN_DIRECTION_INTAKE
         mock_read_int.return_value = FAN_DIR_VALUE_EXHAUST
         assert fan.get_direction() == Fan.FAN_DIRECTION_EXHAUST
+        mock_read_int.return_value = -1 # invalid value
+        assert fan.get_direction() == Fan.FAN_DIRECTION_NOT_APPLICABLE
 
     def test_psu_fan_set_speed(self):
         psu = Psu(0)

--- a/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
@@ -25,7 +25,7 @@ modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
 from sonic_platform import utils
-from sonic_platform.fan import Fan, PsuFan
+from sonic_platform.fan import Fan, PsuFan, FAN_DIR_VALUE_INTAKE, FAN_DIR_VALUE_EXHAUST
 from sonic_platform.fan_drawer import RealDrawer, VirtualDrawer
 from sonic_platform.psu import Psu
 
@@ -107,11 +107,12 @@ class TestFan:
         fan.set_speed(60)
         mock_write_file.assert_called_with(fan.fan_speed_set_path, 153, raise_exception=True)
 
+    @patch('sonic_platform.utils.read_int_from_file')
     @patch('sonic_platform.thermal.Thermal.get_cooling_level')
     @patch('sonic_platform.psu.Psu.get_presence')
     @patch('sonic_platform.psu.Psu.get_powergood_status')
     @patch('os.path.exists')
-    def test_psu_fan_basic(self, mock_path_exists, mock_powergood, mock_presence, mock_cooling_level):
+    def test_psu_fan_basic(self, mock_path_exists, mock_powergood, mock_presence, mock_cooling_level, mock_read_int):
         mock_path_exists.return_value = False
         psu = Psu(0)
         fan = PsuFan(0, 1, psu)
@@ -126,6 +127,10 @@ class TestFan:
         assert fan.get_presence() is True
         mock_cooling_level.return_value = 7
         assert fan.get_target_speed() == 70
+        mock_read_int.return_value = FAN_DIR_VALUE_INTAKE
+        assert fan.get_direction() == Fan.FAN_DIRECTION_INTAKE
+        mock_read_int.return_value = FAN_DIR_VALUE_EXHAUST
+        assert fan.get_direction() == Fan.FAN_DIRECTION_EXHAUST
 
     def test_psu_fan_set_speed(self):
         psu = Psu(0)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add PSU fan direction support

#### How I did it

Implement fan.get_direction for PSU fan

#### How to verify it

Manual test
Unit test
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/platform/mellanox/mlnx-platform-api, configfile: pytest.ini
plugins: pyfakefs-5.1.0, cov-2.10.1
collecting ... collected 109 items

tests/test_chassis.py::TestChassis::test_psu PASSED                      [  0%]
tests/test_chassis.py::TestChassis::test_fan PASSED                      [  1%]
tests/test_chassis.py::TestChassis::test_sfp PASSED                      [  2%]
tests/test_chassis.py::TestChassis::test_change_event PASSED             [  3%]
tests/test_chassis.py::TestChassis::test_reboot_cause PASSED             [  4%]
tests/test_chassis.py::TestChassis::test_parse_warmfast_reboot_from_proc_cmdline PASSED [  5%]
tests/test_chassis.py::TestChassis::test_module PASSED                   [  6%]
tests/test_chassis.py::TestChassis::test_revision_permission PASSED      [  7%]
tests/test_chassis.py::TestChassis::test_get_port_or_cage_type PASSED    [  8%]
tests/test_cpu_thermal_control.py::TestCPUThermalControl::test_run PASSED [  9%]
tests/test_eeprom.py::TestEeprom::test_chassis_eeprom PASSED             [ 10%]
tests/test_eeprom.py::TestEeprom::test_eeprom_init PASSED                [ 11%]
tests/test_eeprom.py::TestEeprom::test_get_system_eeprom_info_from_db PASSED [ 11%]
tests/test_eeprom.py::TestEeprom::test_get_system_eeprom_info_from_hardware PASSED [ 12%]
tests/test_eeprom.py::TestEeprom::test_eeprom_content_visitor PASSED     [ 13%]
tests/test_fan_api.py::TestFan::test_fan_drawer_basic PASSED             [ 14%]
tests/test_fan_api.py::TestFan::test_system_fan_basic PASSED             [ 15%]
tests/test_fan_api.py::TestFan::test_system_fan_set_speed PASSED         [ 16%]
tests/test_fan_api.py::TestFan::test_psu_fan_basic PASSED                [ 17%]
tests/test_fan_api.py::TestFan::test_psu_fan_set_speed PASSED            [ 18%]
tests/test_firmware.py::test_auto_update_firmware_default[None-False-None--2] PASSED [ 19%]
tests/test_firmware.py::test_auto_update_firmware_default[None-True-warm--1] PASSED [ 20%]
tests/test_firmware.py::test_auto_update_firmware_default[mock_update_firmware_fail-True-cold--3] PASSED [ 21%]
tests/test_firmware.py::test_auto_update_firmware_default[mock_update_firmware_success-True-cold-1] PASSED [ 22%]
tests/test_firmware.py::test_auto_update_firmware_cpld[None-False-None--2] PASSED [ 22%]
tests/test_firmware.py::test_auto_update_firmware_cpld[None-True-warm--1] PASSED [ 23%]
tests/test_firmware.py::test_auto_update_firmware_cpld[mock_update_firmware_fail-True-cold--3] PASSED [ 24%]
tests/test_firmware.py::test_auto_update_firmware_cpld[mock_update_firmware_success-True-cold-3] PASSED [ 25%]
tests/test_firmware.py::test_auto_update_firmware_ssd[None-None-False-None--2] PASSED [ 26%]
tests/test_firmware.py::test_auto_update_firmware_ssd[None-mock_update_notification_error-True-None--3] PASSED [ 27%]
tests/test_firmware.py::test_auto_update_firmware_ssd[mock_update_firmware_success-mock_update_notification_cold_boot-True-warm--1] PASSED [ 28%]
tests/test_firmware.py::test_auto_update_firmware_ssd[mock_update_firmware_success-mock_update_notification_cold_boot-True-cold-3] PASSED [ 29%]
tests/test_firmware.py::test_auto_update_firmware_ssd[mock_update_firmware_success-mock_update_notification_warm_boot-True-warm-2] PASSED [ 30%]
tests/test_firmware.py::test_auto_update_firmware_ssd[mock_update_firmware_success-mock_update_notification_warm_boot-True-cold-2] PASSED [ 31%]
tests/test_led.py::TestLed::test_chassis_led PASSED                      [ 32%]
tests/test_led.py::TestLed::test_fan_led PASSED                          [ 33%]
tests/test_led.py::TestLed::test_psu_led PASSED                          [ 33%]
tests/test_led.py::TestLed::test_fixed_psu_led PASSED                    [ 34%]
tests/test_module.py::TestModule::test_chassis_get_num_sfp PASSED        [ 35%]
tests/test_module.py::TestModule::test_chassis_get_all_sfps PASSED       [ 36%]
tests/test_module.py::TestModule::test_chassis_get_sfp PASSED            [ 37%]
tests/test_module.py::TestModule::test_thermal PASSED                    [ 38%]
tests/test_module.py::TestModule::test_check_state PASSED                [ 39%]
tests/test_module.py::TestModule::test_module_vpd PASSED                 [ 40%]
tests/test_psu.py::TestPsu::test_fixed_psu PASSED                        [ 41%]
tests/test_psu.py::TestPsu::test_psu PASSED                              [ 42%]
tests/test_psu.py::TestPsu::test_psu_vpd PASSED                          [ 43%]
tests/test_psu.py::TestPsu::test_psu_workaround PASSED                   [ 44%]
tests/test_psu.py::TestPsu::test_psu_power_threshold PASSED              [ 44%]
tests/test_psu.py::TestPsu::test_psu_not_support_power_threshold PASSED  [ 45%]
tests/test_sfp.py::TestSfp::test_sfp_index PASSED                        [ 46%]
tests/test_sfp.py::TestSfp::test_sfp_get_error_status PASSED             [ 47%]
tests/test_sfp.py::TestSfp::test_sfp_write_eeprom PASSED                 [ 48%]
tests/test_sfp.py::TestSfp::test_sfp_read_eeprom PASSED                  [ 49%]
tests/test_sfp.py::TestSfp::test_is_port_admin_status_up PASSED          [ 50%]
tests/test_sfp.py::TestSfp::test_is_write_protected PASSED               [ 51%]
tests/test_sfp.py::TestSfp::test_get_sfp_type_str PASSED                 [ 52%]
tests/test_sfp.py::TestSfp::test_get_page_and_page_offset PASSED         [ 53%]
tests/test_sfp.py::TestSfp::test_get_presence PASSED                     [ 54%]
tests/test_sfp.py::TestSfp::test_dummy_apis PASSED                       [ 55%]
tests/test_sfp_event.py::TestSfpEvent::test_check_sfp_status PASSED      [ 55%]
tests/test_thermal.py::TestThermal::test_chassis_thermal PASSED          [ 56%]
tests/test_thermal.py::TestThermal::test_chassis_thermal_includes PASSED [ 57%]
tests/test_thermal.py::TestThermal::test_psu_thermal PASSED              [ 58%]
tests/test_thermal.py::TestThermal::test_sfp_thermal PASSED              [ 59%]
tests/test_thermal.py::TestThermal::test_get_temperature PASSED          [ 60%]
tests/test_thermal.py::TestThermal::test_get_high_threshold PASSED       [ 61%]
tests/test_thermal.py::TestThermal::test_get_high_critical_threshold PASSED [ 62%]
tests/test_thermal.py::TestThermal::test_set_thermal_algorithm_status PASSED [ 63%]
tests/test_thermal.py::TestThermal::test_get_min_allowed_cooling_level_by_thermal_zone PASSED [ 64%]
tests/test_thermal.py::TestThermal::test_no_sensor_thermal_zone PASSED   [ 65%]
tests/test_thermal.py::TestThermal::test_check_module_temperature_trustable PASSED [ 66%]
tests/test_thermal.py::TestThermal::test_get_min_amb_temperature PASSED  [ 66%]
tests/test_thermal.py::TestThermal::test_set_cooling_level PASSED        [ 67%]
tests/test_thermal.py::TestThermal::test_set_cooling_state PASSED        [ 68%]
tests/test_thermal.py::TestThermal::test_get_cooling_level PASSED        [ 69%]
tests/test_thermal_policy.py::test_load_policy PASSED                    [ 70%]
tests/test_thermal_policy.py::test_fan_info PASSED                       [ 71%]
tests/test_thermal_policy.py::test_psu_info PASSED                       [ 72%]
tests/test_thermal_policy.py::test_fan_policy PASSED                     [ 73%]
tests/test_thermal_policy.py::test_psu_policy PASSED                     [ 74%]
tests/test_thermal_policy.py::test_any_fan_absence_condition PASSED      [ 75%]
tests/test_thermal_policy.py::test_all_fan_absence_condition PASSED      [ 76%]
tests/test_thermal_policy.py::test_any_fan_fault_condition PASSED        [ 77%]
tests/test_thermal_policy.py::test_all_fan_good_condition PASSED         [ 77%]
tests/test_thermal_policy.py::test_any_psu_absence_condition PASSED      [ 78%]
tests/test_thermal_policy.py::test_all_psu_absence_condition PASSED      [ 79%]
tests/test_thermal_policy.py::test_all_fan_presence_condition PASSED     [ 80%]
tests/test_thermal_policy.py::test_load_set_fan_speed_action PASSED      [ 81%]
tests/test_thermal_policy.py::test_execute_set_fan_speed_action PASSED   [ 82%]
tests/test_thermal_policy.py::test_load_duplicate_condition PASSED       [ 83%]
tests/test_thermal_policy.py::test_load_duplicate_action PASSED          [ 84%]
tests/test_thermal_policy.py::test_load_empty_condition PASSED           [ 85%]
tests/test_thermal_policy.py::test_load_empty_action PASSED              [ 86%]
tests/test_thermal_policy.py::test_load_policy_with_same_conditions PASSED [ 87%]
tests/test_thermal_policy.py::test_dynamic_minimum_table_data PASSED     [ 88%]
tests/test_thermal_policy.py::test_thermal_recover_policy PASSED         [ 88%]
tests/test_thermal_policy.py::test_monitor_asic_themal_zone PASSED       [ 89%]
tests/test_thermal_policy.py::test_set_expect_cooling_level PASSED       [ 90%]
tests/test_thermal_policy.py::test_run_policy PASSED                     [ 91%]
tests/test_utils.py::TestUtils::test_read_file PASSED                    [ 92%]
tests/test_utils.py::TestUtils::test_write_file PASSED                   [ 93%]
tests/test_utils.py::TestUtils::test_pre_initialize PASSED               [ 94%]
tests/test_utils.py::TestUtils::test_pre_initialize_one PASSED           [ 95%]
tests/test_utils.py::TestUtils::test_read_only_cache PASSED              [ 96%]
tests/test_utils.py::TestUtils::test_default_return PASSED               [ 97%]
tests/test_utils.py::TestUtils::test_run_command PASSED                  [ 98%]
tests/test_utils.py::TestUtils::test_extract_RJ45_ports_index PASSED     [ 99%]
tests/test_utils.py::TestUtils::test_wait_until PASSED                   [100%]/usr/lib/python3/dist-packages/pytest_cov/plugin.py:271: PytestWarning: Failed to generate report: No data to report.

  self.cov_controller.finish()
WARNING: Failed to generate report: No data to report.



=============================== warnings summary ===============================
/usr/lib/python3/dist-packages/_pytest/junitxml.py:446
  /usr/lib/python3/dist-packages/_pytest/junitxml.py:446: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0. See:
    https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2
  for more information.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
- generated xml file: /sonic/platform/mellanox/mlnx-platform-api/test-results.xml -

----------- coverage: platform linux, python 3.9.2-final-0 -----------

======================== 109 passed, 1 warning in 5.05s ========================
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

