### PR TITLE
[system-health] Add fan direction check for system health

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -143,7 +143,7 @@ class HardwareChecker(HealthChecker):
                         expect_fan_direction = direction
                     elif direction != expect_fan_direction:
                         self.set_object_not_ok('Fan', name,
-                                               f'{name} direction is wrong, expect:{expect_fan_direction}, got:{direction}')
+                                               f'{name} direction is not aligned, previous:{expect_fan_direction}, current:{direction}')
                         continue
 
             status = data_dict.get('status', 'false')

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -140,10 +140,10 @@ class HardwareChecker(HealthChecker):
                 if direction != 'N/A':
                     if not expect_fan_direction:
                         # initialize the expect fan direction
-                        expect_fan_direction = direction
-                    elif direction != expect_fan_direction:
+                        expect_fan_direction = (name, direction)
+                    elif direction != expect_fan_direction[1]:
                         self.set_object_not_ok('Fan', name,
-                                               f'{name} direction is not aligned, previous:{expect_fan_direction}, current:{direction}')
+                                               f'{name} direction {direction} is not aligned with {expect_fan_direction[0]} direction {expect_fan_direction[1]}')
                         continue
 
             status = data_dict.get('status', 'false')

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -298,14 +298,16 @@ def test_hardware_checker():
             'status': 'True',
             'speed': '60',
             'speed_target': '60',
-            'speed_tolerance': '20'
+            'speed_tolerance': '20',
+            'direction': 'intake'
         },
         'FAN_INFO|fan2': {
             'presence': 'False',
             'status': 'True',
             'speed': '60',
             'speed_target': '60',
-            'speed_tolerance': '20'
+            'speed_tolerance': '20',
+
         },
         'FAN_INFO|fan3': {
             'presence': 'True',
@@ -320,6 +322,14 @@ def test_hardware_checker():
             'speed': '20',
             'speed_target': '60',
             'speed_tolerance': '20'
+        },
+        'FAN_INFO|fan5': {
+            'presence': 'True',
+            'status': 'True',
+            'speed': '60',
+            'speed_target': '60',
+            'speed_tolerance': '20',
+            'direction': 'exhaust'
         }
     })
 
@@ -414,6 +424,10 @@ def test_hardware_checker():
 
     assert 'fan4' in checker._info
     assert checker._info['fan4'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+
+    assert 'fan5' in checker._info
+    assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+    assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'fan5 direction is wrong, expect:intake, got:exhaust'
 
     assert 'PSU 1' in checker._info
     assert checker._info['PSU 1'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -427,7 +427,7 @@ def test_hardware_checker():
 
     assert 'fan5' in checker._info
     assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
-    assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'fan5 direction is not aligned, previous:intake, current:exhaust'
+    assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'fan5 direction exhaust is not aligned with fan1 direction intake'
 
     assert 'PSU 1' in checker._info
     assert checker._info['PSU 1'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -427,7 +427,7 @@ def test_hardware_checker():
 
     assert 'fan5' in checker._info
     assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
-    assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'fan5 direction is wrong, expect:intake, got:exhaust'
+    assert checker._info['fan5'][HealthChecker.INFO_FIELD_OBJECT_MSG] == 'fan5 direction is not aligned, previous:intake, current:exhaust'
 
     assert 'PSU 1' in checker._info
     assert checker._info['PSU 1'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add fan direction check to system health, all fans should be in the same direction

#### How I did it

Add fan direction check to system health, all fans should be in the same direction

#### How to verify it

Manual test
Unit test
Need add sonic-mgmt test case to verify

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

