### PR TITLE
[Mellanox] Remove PSU set speed API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -41,7 +41,6 @@ logger = Logger()
 PWM_MAX = 255
 
 FAN_PATH = "/var/run/hw-management/thermal/"
-CONFIG_PATH = "/var/run/hw-management/config"
 
 FAN_DIR = "/var/run/hw-management/thermal/fan{}_dir"
 FAN_DIR_VALUE_EXHAUST = 0
@@ -160,9 +159,6 @@ class PsuFan(MlnxFan):
         self.fan_presence_path = os.path.join(FAN_PATH, "psu{}_fan1_speed_get".format(self.index))
         self.fan_max_speed_path = os.path.join(FAN_PATH, "psu{}_fan_max".format(self.index))
         self.fan_min_speed_path = os.path.join(FAN_PATH, "psu{}_fan_min".format(self.index))
-        self.psu_i2c_bus_path = os.path.join(CONFIG_PATH, 'psu{0}_i2c_bus'.format(self.index))
-        self.psu_i2c_addr_path = os.path.join(CONFIG_PATH, 'psu{0}_i2c_addr'.format(self.index))
-        self.psu_i2c_command_path = os.path.join(CONFIG_PATH, 'fan_command')
         self.psu_fan_dir_path = os.path.join(FAN_PATH, "psu{}_fan_dir".format(self.index))
 
     def get_direction(self):
@@ -221,34 +217,6 @@ class PsuFan(MlnxFan):
         except Exception:
             return self.get_speed()
 
-    def set_speed(self, speed):
-        """
-        Set fan speed to expected value
-
-        Args:
-            speed: An integer, the percentage of full fan speed to set fan to,
-                   in the range 0 (off) to 100 (full speed)
-
-        Returns:
-            bool: True if set success, False if fail.
-        """
-        if not self.get_presence():
-            return False
-
-        try:
-            bus = utils.read_str_from_file(self.psu_i2c_bus_path, raise_exception=True)
-            addr = utils.read_str_from_file(self.psu_i2c_addr_path, raise_exception=True)
-            command = utils.read_str_from_file(self.psu_i2c_command_path, raise_exception=True)
-            speed = self.PSU_FAN_SPEED[int(speed // 10)]
-            command = ["i2cset", "-f", "-y", bus, addr, command, speed, "wp"]
-            subprocess.check_call(command, universal_newlines=True)
-            return True
-        except subprocess.CalledProcessError as ce:
-            logger.log_error('Failed to call command {}, return code={}, command output={}'.format(ce.cmd, ce.returncode, ce.output))
-            return False
-        except Exception as e:
-            logger.log_error('Failed to set PSU FAN speed - {}'.format(e))
-            return False
 
 class Fan(MlnxFan):
     """Platform-specific Fan class"""

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2019-2023 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2022 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
@@ -133,26 +133,3 @@ class TestFan:
         assert fan.get_direction() == Fan.FAN_DIRECTION_EXHAUST
         mock_read_int.return_value = -1 # invalid value
         assert fan.get_direction() == Fan.FAN_DIRECTION_NOT_APPLICABLE
-
-    def test_psu_fan_set_speed(self):
-        psu = Psu(0)
-        fan = PsuFan(0, 1, psu)
-        subprocess.check_call = MagicMock()
-        mock_file_content = {
-            fan.psu_i2c_bus_path: 'bus',
-            fan.psu_i2c_addr_path: 'addr',
-            fan.psu_i2c_command_path: 'command'
-        }
-        def mock_read_str_from_file(file_path, default='', raise_exception=False):
-            return mock_file_content[file_path]
-        utils.read_str_from_file = mock_read_str_from_file
-        fan.set_speed(60)
-        assert subprocess.check_call.call_count == 0
-        fan.get_presence = MagicMock(return_value=True)
-        assert fan.set_speed(60)
-        subprocess.check_call.assert_called_with(["i2cset", "-f", "-y", "bus", "addr", "command", hex(60), "wp"], universal_newlines=True)
-        subprocess.check_call = MagicMock(side_effect=subprocess.CalledProcessError('', ''))
-        assert not fan.set_speed(60)
-        subprocess.check_call = MagicMock()
-        utils.read_str_from_file = MagicMock(side_effect=RuntimeError(''))
-        assert not fan.set_speed(60)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Based on new mellanox thermal control design, PSU fan speed is controlled by hw-management-tc service and PSU firmware. It is not allowed for user to control PSU fan speed via platform API.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Remove set_speed API for PSU fan

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

