### PR TITLE
[Mellanox] implement sfp.reset for independent module

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -216,3 +216,12 @@ class DeviceDataManager:
             # Currently, only fetching BIOS version is supported
             return ComponentCPLDSN2201.get_component_list()
         return ComponentCPLD.get_component_list()
+
+    @classmethod
+    @utils.read_only_cache()
+    def is_independent_mode(cls):
+        from sonic_py_common import device_info
+        _, hwsku_dir = device_info.get_paths_to_platform_and_hwsku_dirs()
+        sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
+        data = utils.read_key_value_file(sai_profile_file, delimeter='=')
+        return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -138,6 +138,7 @@ SFP_SYSFS_STATUS = 'status'
 SFP_SYSFS_STATUS_ERROR = 'statuserror'
 SFP_SYSFS_PRESENT = 'present'
 SFP_SYSFS_RESET = 'reset'
+SFP_SYSFS_HWRESET = 'hw_reset'
 SFP_SYSFS_POWER_MODE = 'power_mode'
 SFP_SYSFS_POWER_MODE_POLICY = 'power_mode_policy'
 POWER_MODE_POLICY_HIGH = 1
@@ -380,8 +381,17 @@ class SFP(NvidiaSFPCommon):
 
         refer plugins/sfpreset.py
         """
-        file_path = SFP_SDK_MODULE_SYSFS_ROOT_TEMPLATE.format(self.sdk_index) + SFP_SYSFS_RESET
-        return utils.write_file(file_path, '1')
+        try:
+            if not self.is_sw_control():
+                file_path = SFP_SDK_MODULE_SYSFS_ROOT_TEMPLATE.format(self.sdk_index) + SFP_SYSFS_RESET
+                return utils.write_file(file_path, '1')
+            else:
+                file_path = SFP_SDK_MODULE_SYSFS_ROOT_TEMPLATE.format(self.sdk_index) + SFP_SYSFS_HWRESET
+                return utils.write_file(file_path, '0') and utils.write_file(file_path, '1')
+        except Exception as e:
+            print(f'Failed to reset module - {e}')
+            logger.log_error(f'Failed to reset module - {e}')
+            return False
 
     def set_lpmode(self, lpmode):
         """
@@ -589,6 +599,17 @@ class SFP(NvidiaSFPCommon):
                 self._xcvr_api.get_rx_los = self.get_rx_los
                 self._xcvr_api.get_tx_fault = self.get_tx_fault
         return self._xcvr_api
+
+    def is_sw_control(self):
+        if not DeviceDataManager.is_independent_mode():
+            return False
+
+        db = utils.DbUtils.get_db_instance('STATE_DB')
+        control_type = db.get('STATE_DB', f'TRANSCEIVER_MODULES_MGMT|{self.sdk_index}', 'control_type')
+        if not control_type:
+            raise Exception(f'Module {self.sdk_index} is in initialization, please retry later')
+
+        return control_type == 'SW_CONTROL'
 
 
 class RJ45Port(NvidiaSFPCommon):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,8 @@ PORT_TYPE_KEY = "port_type"
 RJ45_PORT_TYPE = "RJ45"
 
 logger = Logger()
+
+db_instances = None
 
 
 def read_from_file(file_path, target_type, default='', raise_exception=False, log_func=logger.log_error):
@@ -100,15 +102,15 @@ def read_float_from_file(file_path, default=0.0, raise_exception=False, log_func
     return read_from_file(file_path=file_path, target_type=float, default=default, raise_exception=raise_exception, log_func=log_func)
 
 
-def _key_value_converter(content):
+def _key_value_converter(content, delimeter):
     ret = {}
     for line in content.splitlines():
-        k,v = line.split(':')
+        k,v = line.split(delimeter)
         ret[k.strip()] = v.strip()
     return ret
 
 
-def read_key_value_file(file_path, default={}, raise_exception=False, log_func=logger.log_error):
+def read_key_value_file(file_path, default={}, raise_exception=False, log_func=logger.log_error, delimeter=':'):
     """Read file content and parse the content to a dict. The file content should like:
        key1:value1
        key2:value2
@@ -119,7 +121,8 @@ def read_key_value_file(file_path, default={}, raise_exception=False, log_func=l
         raise_exception (bool, optional): If exception should be raised or hiden. Defaults to False.
         log_func (optional): logger function.. Defaults to logger.log_error.
     """
-    return read_from_file(file_path=file_path, target_type=_key_value_converter, default=default, raise_exception=raise_exception, log_func=log_func)
+    converter = lambda content: _key_value_converter(content, delimeter)
+    return read_from_file(file_path=file_path, target_type=converter, default=default, raise_exception=raise_exception, log_func=log_func)
 
 
 def write_file(file_path, content, raise_exception=False, log_func=logger.log_error):
@@ -285,3 +288,22 @@ def wait_until(predict, timeout, interval=1, *args, **kwargs):
         time.sleep(interval)
         timeout -= interval
     return False
+
+
+class DbUtils:
+    db_instances = {}
+
+    @classmethod
+    def get_db_instance(cls, db_name, **kargs):
+        try:
+            if db_name not in cls.db_instances:
+                from sonic_py_common import multi_asic
+                from swsscommon.swsscommon import SonicV2Connector
+                namespace = multi_asic.get_current_namespace()
+                db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)
+                db.connect(db_name)
+                cls.db_instances[db_name] = db
+            return cls.db_instances[db_name]
+        except Exception as e:
+            logger.log_error(f'Failed to get DB instance for DB {db_name} - {e}')
+            raise e

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -52,5 +52,14 @@ class TestDeviceData:
     def test_get_bios_component(self):
         assert DeviceDataManager.get_bios_component() is not None
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=('', '/tmp')))
+    @mock.patch('sonic_platform.device_data.utils.read_key_value_file')
+    def test_is_independent_mode(self, mock_read):
+        mock_read.return_value = {}
+        assert not DeviceDataManager.is_independent_mode()
+        mock_read.return_value = {'SAI_INDEPENDENT_MODULE_MODE': '1'}
+        assert DeviceDataManager.is_independent_mode()
+
+
 
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -244,9 +244,14 @@ class TestSfp:
     @mock.patch('sonic_platform.utils.write_file')
     def test_reset(self, mock_write):
         sfp = SFP(0)
+        sfp.is_sw_control = mock.MagicMock(return_value=False)
         mock_write.return_value = True
         assert sfp.reset()
         mock_write.assert_called_with('/sys/module/sx_core/asic0/module0/reset', '1')
+        sfp.is_sw_control.return_value = True
+        assert sfp.reset()
+        sfp.is_sw_control.side_effect = Exception('')
+        assert not sfp.reset()
 
     @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_get_lpmode(self, mock_read_int):
@@ -290,3 +295,22 @@ class TestSfp:
         assert sfp.get_transceiver_bulk_status()
         assert sfp.get_transceiver_threshold_info()
         sfp.reinit()
+
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.is_independent_mode')
+    @mock.patch('sonic_platform.utils.DbUtils.get_db_instance')
+    def test_is_sw_control(self, mock_get_db, mock_mode):
+        sfp = SFP(0)
+        mock_mode.return_value = False
+        assert not sfp.is_sw_control()
+        mock_mode.return_value = True
+
+        mock_db = mock.MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_db.get = mock.MagicMock(return_value=None)
+        with pytest.raises(Exception):
+            sfp.is_sw_control()
+
+        mock_db.get.return_value = 'FW_CONTROL'
+        assert not sfp.is_sw_control()
+        mock_db.get.return_value = 'SW_CONTROL'
+        assert sfp.is_sw_control()

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -191,3 +191,6 @@ class TestUtils:
         mock_os_open = mock.mock_open(read_data='a:b')
         with mock.patch('sonic_platform.utils.open', mock_os_open):
             assert utils.read_key_value_file('some_file') == {'a':'b'}
+        mock_os_open = mock.mock_open(read_data='a=b')
+        with mock.patch('sonic_platform.utils.open', mock_os_open):
+            assert utils.read_key_value_file('some_file', delimeter='=') == {'a':'b'}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

For independent module, we need a different implementation for `sfp.reset`. This PR is to implement it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. For independent module, do reset from hw_reset
2. For dependent module, do reset as the original way

#### How to verify it

Manual test
sonic-mgmt platform test
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

