### PR TITLE
[Mellanox] Provide default implementation for sfp error description when CMIS host management is enabled

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -227,3 +227,12 @@ class DeviceDataManager:
             # Currently, only fetching BIOS version is supported
             return ComponentCPLDSN2201.get_component_list()
         return ComponentCPLD.get_component_list()
+
+    @classmethod
+    @utils.read_only_cache()
+    def is_independent_mode(cls):
+        from sonic_py_common import device_info
+        _, hwsku_dir = device_info.get_paths_to_platform_and_hwsku_dirs()
+        sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
+        data = utils.read_key_value_file(sai_profile_file, delimeter='=')
+        return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -120,6 +120,7 @@ SFP_SYSFS_STATUS = 'status'
 SFP_SYSFS_STATUS_ERROR = 'statuserror'
 SFP_SYSFS_PRESENT = 'present'
 SFP_SYSFS_RESET = 'reset'
+SFP_SYSFS_HWRESET = 'hw_reset'
 SFP_SYSFS_POWER_MODE = 'power_mode'
 SFP_SYSFS_POWER_MODE_POLICY = 'power_mode_policy'
 POWER_MODE_POLICY_HIGH = 1
@@ -387,6 +388,12 @@ class SFP(NvidiaSFPCommon):
         Returns:
             The error description
         """
+        try:
+            if self.is_sw_control():
+                return 'Not supported'
+        except:
+            return self.SFP_STATUS_INITIALIZING
+
         oper_status, error_code = self._get_module_info(self.sdk_index)
         if oper_status == SX_PORT_MODULE_STATUS_INITIALIZING:
             error_description = self.SFP_STATUS_INITIALIZING
@@ -540,6 +547,21 @@ class SFP(NvidiaSFPCommon):
                 self._xcvr_api.get_rx_los = self.get_rx_los
                 self._xcvr_api.get_tx_fault = self.get_tx_fault
         return self._xcvr_api
+
+    def is_sw_control(self):
+        if not DeviceDataManager.is_independent_mode():
+            return False
+
+        db = utils.DbUtils.get_db_instance('STATE_DB')
+        control_type = db.get('STATE_DB', f'TRANSCEIVER_MODULES_MGMT|{self.sdk_index}', 'control_type')
+        control_file_value = utils.read_int_from_file(f'/sys/module/sx_core/asic0/module{self.sdk_index}/control')
+
+        if control_type == 'SW_CONTROL' and control_file_value == 1:
+            return True
+        elif control_type == 'FW_CONTROL' and control_file_value == 0:
+            return False
+        else:
+            raise Exception(f'Module {self.sdk_index} is in initialization, please retry later')
 
 
 class RJ45Port(NvidiaSFPCommon):

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -52,5 +52,14 @@ class TestDeviceData:
     def test_get_bios_component(self):
         assert DeviceDataManager.get_bios_component() is not None
 
+    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=('', '/tmp')))
+    @mock.patch('sonic_platform.device_data.utils.read_key_value_file')
+    def test_is_independent_mode(self, mock_read):
+        mock_read.return_value = {}
+        assert not DeviceDataManager.is_independent_mode()
+        mock_read.return_value = {'SAI_INDEPENDENT_MODULE_MODE': '1'}
+        assert DeviceDataManager.is_independent_mode()
+
+
 
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -54,16 +54,17 @@ class TestSfp:
         assert sfp.sdk_index == 1
         assert sfp.index == 5
 
+    @mock.patch('sonic_platform.sfp.SFP.is_sw_control')
     @mock.patch('sonic_platform.sfp.SFP.read_eeprom', mock.MagicMock(return_value=None))
     @mock.patch('sonic_platform.sfp.SFP._get_module_info')
     @mock.patch('sonic_platform.chassis.Chassis.get_num_sfps', mock.MagicMock(return_value=2))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
-    def test_sfp_get_error_status(self, mock_get_error_code):
+    def test_sfp_get_error_status(self, mock_get_error_code, mock_control):
         chassis = Chassis()
 
         # Fetch an SFP module to test
         sfp = chassis.get_sfp(1)
-
+        mock_control.return_value = False
         description_dict = sfp._get_error_description_dict()
         for error in description_dict.keys():
             mock_get_error_code.return_value = (SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR, error)
@@ -86,6 +87,14 @@ class TestSfp:
             description = sfp.get_error_description()
 
             assert description == expected_description
+
+        mock_control.return_value = True
+        description = sfp.get_error_description()
+        assert description == 'Not supported'
+
+        mock_control.side_effect = RuntimeError('')
+        description = sfp.get_error_description()
+        assert description == 'Initializing'
 
     @mock.patch('sonic_platform.sfp.SFP._get_page_and_page_offset')
     @mock.patch('sonic_platform.sfp.SFP._is_write_protected')
@@ -289,3 +298,28 @@ class TestSfp:
         assert sfp.get_transceiver_bulk_status()
         assert sfp.get_transceiver_threshold_info()
         sfp.reinit()
+
+    @mock.patch('sonic_platform.utils.read_int_from_file')
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.is_independent_mode')
+    @mock.patch('sonic_platform.utils.DbUtils.get_db_instance')
+    def test_is_sw_control(self, mock_get_db, mock_mode, mock_read):
+        sfp = SFP(0)
+        mock_mode.return_value = False
+        assert not sfp.is_sw_control()
+        mock_mode.return_value = True
+
+        mock_db = mock.MagicMock()
+        mock_get_db.return_value = mock_db
+        mock_db.get = mock.MagicMock(return_value=None)
+        with pytest.raises(Exception):
+            sfp.is_sw_control()
+
+        mock_read.return_value = 0
+        mock_db.get.return_value = 'FW_CONTROL'
+        assert not sfp.is_sw_control()
+        mock_read.return_value = 1
+        mock_db.get.return_value = 'SW_CONTROL'
+        assert sfp.is_sw_control()
+        mock_read.return_value = 0
+        with pytest.raises(Exception):
+            sfp.is_sw_control()

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -191,3 +191,6 @@ class TestUtils:
         mock_os_open = mock.mock_open(read_data='a:b')
         with mock.patch('sonic_platform.utils.open', mock_os_open):
             assert utils.read_key_value_file('some_file') == {'a':'b'}
+        mock_os_open = mock.mock_open(read_data='a=b')
+        with mock.patch('sonic_platform.utils.open', mock_os_open):
+            assert utils.read_key_value_file('some_file', delimeter='=') == {'a':'b'}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Provide a dummy implementation for SFP error description when CMIS host management is enabled.  A future feature shall be raised to implement SFP error description for such mode.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. if SFP is under software control, provide "Not supported" as error description
2. if SFP is under initialization, provide "Initializing" as error description

#### How to verify it

unit test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

