### PR TITLE
Python logger enhancement to support setting log level at real time

### DIFF
--- a/src/sonic-py-common/sonic_py_common/logger.py
+++ b/src/sonic-py-common/sonic_py_common/logger.py
@@ -57,7 +57,9 @@ class Logger(object):
                 # Expect the 'mock' package for python 2
                 # https://pypi.python.org/pypi/mock
                 import mock
-            return mock.MagicMock()
+            instance = mock.MagicMock()
+            instance.getMinPrio.return_value = self.LOG_PRIORITY_NOTICE
+            return instance
 
     #
     # Methods for setting minimum log priority

--- a/src/sonic-py-common/tests/logger_test.py
+++ b/src/sonic-py-common/tests/logger_test.py
@@ -1,4 +1,12 @@
-from unittest import mock
+import sys
+
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    # Expect the 'mock' package for python 2
+    # https://pypi.python.org/pypi/mock
+    import mock
+
 from sonic_py_common import logger
 
 

--- a/src/sonic-py-common/tests/logger_test.py
+++ b/src/sonic-py-common/tests/logger_test.py
@@ -1,0 +1,45 @@
+from unittest import mock
+from sonic_py_common import logger
+
+
+class TestLogger:
+    def test_log(self):
+        log = logger.Logger()
+        mock_log = mock.MagicMock()
+        mock_log.write = mock.MagicMock()
+        mock_log.getMinPrio.return_value = logger.Logger.LOG_PRIORITY_DEBUG
+
+        log._log = mock_log
+        log.set_min_log_priority(logger.Logger.LOG_PRIORITY_DEBUG)
+
+        log.log_debug('debug message')
+        mock_log.write.assert_called_with(logger.Logger.LOG_PRIORITY_DEBUG, 'debug message')
+
+        log.log_info('info message')
+        mock_log.write.assert_called_with(logger.Logger.LOG_PRIORITY_INFO, 'info message')
+
+        log.log_notice('notice message')
+        mock_log.write.assert_called_with(logger.Logger.LOG_PRIORITY_NOTICE, 'notice message')
+
+        log.log_error('error message')
+        mock_log.write.assert_called_with(logger.Logger.LOG_PRIORITY_ERROR, 'error message')
+
+        log.log_warning('warning message')
+        mock_log.write.assert_called_with(logger.Logger.LOG_PRIORITY_WARNING, 'warning message')
+
+        mock_log.getMinPrio.return_value = logger.Logger.LOG_PRIORITY_INFO
+        mock_log.write.reset_mock()
+        log.log_debug('debug message')
+        mock_log.write.assert_not_called()
+
+        log.log_info('info message', also_print_to_console=True)
+        log.log_info('info message')
+        mock_log.write.assert_called_with(logger.Logger.LOG_PRIORITY_INFO, 'info message')
+
+    def test_set_log_level(self):
+        log = logger.Logger()
+        log.set_min_log_priority_error()
+        log.set_min_log_priority_warning()
+        log.set_min_log_priority_notice()
+        log.set_min_log_priority_info()
+        log.set_min_log_priority_debug()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Python logger does not setting log level at real time, this PR is aimed to enhance it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use swsscommon.Logger as a internal logger of `sonic_py_common.logger.Logger`

#### How to verify it

unit test
manual test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

