### PR TITLE
[Mellanox] wait until hw-management watchdog files ready

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
@@ -283,7 +283,8 @@ def get_watchdog():
     """
     Return WatchdogType1 or WatchdogType2 based on system
     """
-
+    
+    utils.wait_until(lambda: os.path.exists('/run/hw-management/watchdog/main/state'), timeout=10, interval=1)
     watchdog_main_device_name = None
 
     for device in os.listdir("/dev/"):

--- a/platform/mellanox/mlnx-platform-api/tests/test_watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_watchdog.py
@@ -36,6 +36,7 @@ from sonic_platform.watchdog import get_watchdog,    \
 
 
 class TestWatchdog:
+    @mock.patch('sonic_platform.utils.wait_until', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.is_mlnx_wd_main')
     @mock.patch('sonic_platform.watchdog.os.listdir')
     def test_get_watchdog_no_device(self, mock_listdir, mock_is_main):
@@ -50,6 +51,7 @@ class TestWatchdog:
         mock_is_main.return_value = False
         assert get_watchdog() is None
 
+    @mock.patch('sonic_platform.utils.wait_until', mock.MagicMock())
     @mock.patch('sonic_platform.watchdog.is_mlnx_wd_main')
     @mock.patch('sonic_platform.watchdog.is_wd_type2')
     @mock.patch('sonic_platform.watchdog.os.listdir', mock.MagicMock(return_value=['watchdog1', 'watchdog2']))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

watchdog-control service always disarm watchdog during system startup stage. It could be the case that watchdog is not fully initialized while the watchdog-control service is accessing it. This PR adds a wait to make sure watchdog has been fully initialized.  

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

adds a wait to make sure watchdog has been fully initialized.  

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Manual test
sonic  regression

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

