### PR TITLE
[Mellanox] Fix error log after warm reboot

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -169,16 +169,19 @@ class ModulesMgmtTask(threading.Thread):
             module_fd_indep_path = SYSFS_INDEPENDENT_FD_PRESENCE.format(port)
             logger.log_info("system in indep mode: {} port {}".format(self.is_supported_indep_mods_system, port))
             if self.is_warm_reboot:
-                logger.log_info("system was warm rebooted is_warm_reboot: {} trying to read control sysfs for port {}"
-                                .format(self.is_warm_reboot, port))
-                port_control_file = SYSFS_INDEPENDENT_FD_FW_CONTROL.format(port)
-                try:
-                    port_control = utils.read_int_from_file(port_control_file, raise_exception=True)
-                    self.port_control_dict[port] = port_control
-                    logger.log_info(f"port control sysfs is {port_control} for port {port}")
-                except Exception as e:
-                    logger.log_error("exception {} for port {} trying to read port control sysfs {}"
-                                     .format(e, port, port_control_file))
+                if self.is_supported_indep_mods_system:
+                    logger.log_info("system was warm rebooted is_warm_reboot: {} trying to read control sysfs for port {}"
+                                    .format(self.is_warm_reboot, port))
+                    port_control_file = SYSFS_INDEPENDENT_FD_FW_CONTROL.format(port)
+                    try:
+                        port_control = utils.read_int_from_file(port_control_file, raise_exception=True)
+                        self.port_control_dict[port] = port_control
+                        logger.log_info(f"port control sysfs is {port_control} for port {port}")
+                    except Exception as e:
+                        logger.log_error("exception {} for port {} trying to read port control sysfs {}"
+                                        .format(e, port, port_control_file))
+                else:
+                    self.port_control_dict[port] = 0
             if (self.is_supported_indep_mods_system and os.path.isfile(module_fd_indep_path)) \
                     and not (self.is_warm_reboot and 0 == port_control):
                 logger.log_info("system in indep mode: {} port {} reading file {}".format(self.is_supported_indep_mods_system, port, module_fd_indep_path))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

There are error logs if doing warm reboot on a system which does not enable module host management.

```
Mar 13 12:00:20.920599 sonic ERR pmon#xcvrd: exception [Errno 2] No such file or directory: '/sys/module/sx_core/asic0/module63/control' for port 63 trying to read port control sysfs /sys/module/sx_core/asic0/module63/control

Mar 13 12:00:20.920659 sonic ERR pmon#xcvrd: Failed to read from file /sys/module/sx_core/asic0/module64/control - FileNotFoundError(2, 'No such file or directory')
``` 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Only check sysfs /sys/module/sx_core/asic0/module{num}/control if module host management is enabled.

#### How to verify it

Manual test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

