### PR TITLE
Add multi ASIC support for syslog rate limit feature

### DIFF
--- a/src/sonic-containercfgd/containercfgd/containercfgd.py
+++ b/src/sonic-containercfgd/containercfgd/containercfgd.py
@@ -23,6 +23,7 @@ SYSLOG_RATE_LIMIT_BURST = 'rate_limit_burst'
 
 # Container name
 container_name = None
+service_name = None
 
 
 def run_command(command):
@@ -117,7 +118,7 @@ class SyslogHandler:
             data (dict): Data of the entry: {<field_name>: <field_value>}
         """
         try:
-            if key != container_name:
+            if key != service_name:
                 return
             self.update_syslog_config(data)
         except Exception as e:
@@ -130,8 +131,8 @@ class SyslogHandler:
             init_data (dict): Initial data when first time connecting to CONFIG DB. {<table_name>: {<field_name>: <field_value>}}
         """
         if SYSLOG_CONFIG_FEATURE_TABLE in init_data:
-            if container_name in init_data[SYSLOG_CONFIG_FEATURE_TABLE]:
-                self.update_syslog_config(init_data[SYSLOG_CONFIG_FEATURE_TABLE][container_name])
+            if service_name in init_data[SYSLOG_CONFIG_FEATURE_TABLE]:
+                self.update_syslog_config(init_data[SYSLOG_CONFIG_FEATURE_TABLE][service_name])
 
     def update_syslog_config(self, data):
         """Parse existing syslog conf and apply new syslog conf.
@@ -185,7 +186,13 @@ class SyslogHandler:
 
 def main():
     global container_name
+    global service_name
+    namespace_id = os.environ['NAMESPACE_ID']
     container_name = os.environ['CONTAINER_NAME']
+    if not namespace_id:
+        service_name = container_name
+    else:
+        service_name = container_name.rstrip(namespace_id)
     daemon = ContainerConfigDaemon()
     daemon.run()
 

--- a/src/sonic-containercfgd/tests/test_syslog_config.py
+++ b/src/sonic-containercfgd/tests/test_syslog_config.py
@@ -12,6 +12,7 @@ sys.path.insert(0, modules_path)
 from containercfgd import containercfgd
 
 containercfgd.container_name = 'swss'
+containercfgd.service_name = 'swss'
 
 
 def test_handle_config():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

For multi asic platform, the container name is not the same as service name. For example, service name swss, the container in namespace asic0 will have container name swss0. This PR is to support multi ASIC platform.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add a global variable service_name and use it to match DB key.

#### How to verify it

Manual test
Unit test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

