### PR TITLE
Add log configuration handler to handle log level change in CONFIG DB

### DIFF
--- a/src/sonic-py-common/sonic_py_common/logger.py
+++ b/src/sonic-py-common/sonic_py_common/logger.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import syslog
+from . import logger_config_handler
 
 """
 Logging functionality for SONiC Python applications
@@ -25,8 +26,14 @@ class Logger(object):
 
     DEFAULT_LOG_FACILITY = LOG_FACILITY_USER
     DEFAULT_LOG_OPTION = LOG_OPTION_NDELAY
+    
+    config_handler = logger_config_handler.LoggerConfigHandler()
 
-    def __init__(self, log_identifier=None, log_facility=DEFAULT_LOG_FACILITY, log_option=DEFAULT_LOG_OPTION):
+    def __init__(self, log_identifier=None,
+                       log_facility=DEFAULT_LOG_FACILITY,
+                       log_option=DEFAULT_LOG_OPTION,
+                       log_level=LOG_PRIORITY_NOTICE,
+                       enable_config_thread=False):
         self._syslog = syslog
 
         if log_identifier is None:
@@ -35,12 +42,63 @@ class Logger(object):
         # Initialize syslog
         self._syslog.openlog(ident=log_identifier, logoption=log_option, facility=log_facility)
 
-        # Set the default minimum log priority to LOG_PRIORITY_NOTICE
-        self.set_min_log_priority(self.LOG_PRIORITY_NOTICE)
+        # Set the default log priority
+        self.set_min_log_priority(log_level)
+        
+        Logger.config_handler.register(self, log_identifier, self.log_priority_to_str(log_level))
+        
+        if enable_config_thread:
+            Logger.config_handler.start()
 
     def __del__(self):
         self._syslog.closelog()
 
+    def log_priority_to_str(self, priority):
+        """Convert log priority to string.
+
+        Args:
+            priority (int): log priority.
+
+        Returns:
+            str: log priority in string.
+        """
+        if priority == Logger.LOG_PRIORITY_NOTICE:
+            return 'NOTICE'
+        elif priority == Logger.LOG_PRIORITY_INFO:
+            return 'INFO'
+        elif priority == Logger.LOG_PRIORITY_DEBUG:
+            return 'DEBUG'
+        elif priority == Logger.LOG_PRIORITY_WARNING:
+            return 'WARN'
+        elif priority == Logger.LOG_PRIORITY_ERROR:
+            return 'ERROR'
+        else:
+            self.log_error(f'Invalid log priority: {priority}')
+            return 'NOTICE'
+    
+    def log_priority_from_str(self, priority_in_str):
+        """Convert log priority from string.
+
+        Args:
+            priority_in_str (str): log priority in string.
+
+        Returns:
+            _type_: log priority.
+        """
+        if priority_in_str == 'DEBUG':
+            return Logger.LOG_PRIORITY_DEBUG
+        elif priority_in_str == 'INFO':
+            return Logger.LOG_PRIORITY_INFO
+        elif priority_in_str == 'NOTICE':
+            return Logger.LOG_PRIORITY_NOTICE
+        elif priority_in_str == 'WARN':
+            return Logger.LOG_PRIORITY_WARNING
+        elif priority_in_str == 'ERROR':
+            return Logger.LOG_PRIORITY_ERROR
+        else:
+            self.log_error(f'Invalid log priority string: {priority_in_str}')
+            return Logger.LOG_PRIORITY_NOTICE
+        
     #
     # Methods for setting minimum log priority
     #

--- a/src/sonic-py-common/sonic_py_common/logger_config_handler.py
+++ b/src/sonic-py-common/sonic_py_common/logger_config_handler.py
@@ -1,0 +1,153 @@
+import queue
+import redis
+import time
+import threading
+
+CONFIG_DB = 4
+SUBSCRIBE_PATTERN = '__keyspace@4__:LOGGER|*'
+SUBSCRIBE_TIMEOUT = 1
+LOGGER_TABLE_NAME = 'LOGGER'
+LOGGER_FIELD_LEVEL = 'LOGLEVEL'
+TABLE_SEPARATOR = '|'
+MESSAGE_FIELD_CHANNEL = 'channel'
+MESSAGE_FIELD_DATA = 'data'
+MESSAGE_OP_HSET = 'hset'
+
+
+def format_table_key(db_name):
+    return '{}{}{}'.format(LOGGER_TABLE_NAME, TABLE_SEPARATOR, db_name)
+
+
+class LoggerConfigThread(threading.Thread):
+    def __init__(self):
+        super().__init__(daemon=True)
+        # queue to store logger instances that are pending registered
+        self.queue = queue.Queue()
+        
+        # dict to store <db_key, log_instances>
+        self.log_registry = {}
+        self.running = False
+        
+    def stop(self):
+        self.running = False
+        
+    def run(self):
+        self.running = True
+        db = None
+        
+        # Wait until DB is ready. Logger instance shall use default 
+        # log level before DB is ready.
+        while True:
+            if not self.running:
+                return
+            try:
+                # Cannot use redis related APIs defined in swsscommon because there is a potential
+                # issue in swsscommon.i which calls PyEval_RestoreThread in a C++ destructor.
+                # PyEval_RestoreThread may raise exception abi::__forced_unwind while python is
+                # exiting. C++ standard does not allow exception in a destructor and it would cause
+                # unexpected termination. A detailed explanation can be found in 
+                # PR description https://github.com/sonic-net/sonic-buildimage/pull/12255.
+                db = redis.Redis(db=4, encoding="utf-8", decode_responses=True)
+                pubsub = db.pubsub()
+                pubsub.psubscribe(SUBSCRIBE_PATTERN)
+                break
+            except:
+                time.sleep(5)
+                continue
+            
+        while self.running:
+            # Process registered logger instance from the queue
+            while self.running:
+                try:
+                    item = self.queue.get_nowait()
+                    log_instance = item[0]
+                    db_key = item[1]
+                    default_level = item[2]
+                    table_key = format_table_key(db_key)
+                    log_level = db.hget(table_key, LOGGER_FIELD_LEVEL)
+                    if db_key not in self.log_registry:
+                        # register logger to DB if the db_key is new
+                        self.log_registry[db_key] = [log_instance]
+                        if not log_level:
+                            db.hset(table_key, LOGGER_FIELD_LEVEL, default_level)
+                    else:
+                        self.log_registry[db_key].append(log_instance)
+                    if log_level:
+                        log_instance.set_min_log_priority(log_instance.log_priority_from_str(log_level))
+                except queue.Empty:
+                    # no more registered logger instance, break the loop
+                    break
+            
+            try:
+                message = pubsub.get_message()
+                if message:
+                    key = message[MESSAGE_FIELD_CHANNEL].split(':', 1)[1]
+                    db_name = key.split(TABLE_SEPARATOR)[1]
+                    op = message[MESSAGE_FIELD_DATA]
+                
+                    if op != MESSAGE_OP_HSET or db_name not in self.log_registry:
+                        continue
+                    
+                    log_level = db.hget(key, LOGGER_FIELD_LEVEL)
+                    # update log level for all log instances with the given db_name
+                    for log_instance in self.log_registry[db_name]:
+                        log_instance.set_min_log_priority(log_instance.log_priority_from_str(log_level))
+                else:
+                    time.sleep(SUBSCRIBE_TIMEOUT)
+            except redis.exceptions.ConnectionError:
+                # redis server is done, exit
+                return
+
+
+class LoggerConfigHandler:
+    # global Logger configuration thread instance
+    log_config_thread = LoggerConfigThread()
+    
+    # flag to indicate that log thread has started
+    log_thread_started = False
+    
+    # lock to protect log_thread_started
+    log_thread_lock = threading.Lock()
+    
+    @classmethod
+    def start(cls):
+        """Start logger configuration thread if it is not started yet
+        """
+        if not cls.log_thread_started:
+            with cls.log_thread_lock:
+                if not cls.log_thread_started:
+                    cls.log_config_thread.start()
+                    cls.log_thread_started = True
+
+    @classmethod
+    def stop(cls):
+        """Stop logger configuration thread, only used in UT
+        """
+        with cls.log_thread_lock:
+            if cls.log_thread_started:
+                cls.log_config_thread.stop()
+                cls.log_config_thread.join()
+                cls.reset()
+                    
+    @classmethod
+    def reset(cls):
+        """Reset logger configuration thread for multi-processing case.
+
+           Linux does not clone the thread while doing fork. In case user creates a sub process
+           and still want to set log level on fly, user must call this function before creating
+           logger instance.
+        """
+        cls.log_config_thread = LoggerConfigThread()
+        cls.log_thread_started = False
+                    
+    @classmethod
+    def register(cls, instance, db_key, default_level):
+        """Register logger instance. A new logger entry will be added to CONFIG DB LOGGER
+        table once logger configuration thread is started.
+
+        Args:
+            instance (object): logger instance.
+            db_key (str): key of LOGGER table. Usually use the log identifier as the key.
+            default_level (str): one of NOTICE, DEBUG, INFO, ERROR, WARNING.
+        """
+        cls.log_config_thread.queue.put((instance, db_key, default_level))

--- a/src/sonic-py-common/tests/test_logger.py
+++ b/src/sonic-py-common/tests/test_logger.py
@@ -1,0 +1,168 @@
+import logging
+import os
+import pytest
+import sys
+import time
+
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'sonic_py_common'))
+from sonic_py_common import logger, syslogger
+
+
+@pytest.fixture()
+def auto_stop():
+    logger.Logger.config_handler.stop()
+
+
+def wait_until(predict, timeout, interval=1, *args, **kwargs):
+    """Wait until a condition become true
+
+    Args:
+        predict (object): a callable such as function, lambda
+        timeout (int): wait time in seconds
+        interval (int, optional): interval to check the predict. Defaults to 1.
+
+    Returns:
+        _type_: _description_
+    """
+    if predict(*args, **kwargs):
+        return True
+    while timeout > 0:
+        time.sleep(interval)
+        timeout -= interval
+        if predict(*args, **kwargs):
+            return True
+    return False
+
+
+class TestLogger:
+    def test_basic(self):
+        log = logger.Logger()
+        log.log_error('error message')
+        log.log_warning('warning message')
+        log.log_notice('notice message')
+        log.log_info('info message')
+        log.log_debug('debug message')
+        log.log(log.LOG_PRIORITY_ERROR, 'error msg', also_print_to_console=True)
+        
+    def test_log_priority(self):
+        log = logger.Logger()
+        log.set_min_log_priority_error()
+        assert log._min_log_priority == log.LOG_PRIORITY_ERROR
+        log.set_min_log_priority_warning()
+        assert log._min_log_priority == log.LOG_PRIORITY_WARNING
+        log.set_min_log_priority_notice()
+        assert log._min_log_priority == log.LOG_PRIORITY_NOTICE
+        log.set_min_log_priority_info()
+        assert log._min_log_priority == log.LOG_PRIORITY_INFO
+        log.set_min_log_priority_debug()
+        assert log._min_log_priority == log.LOG_PRIORITY_DEBUG
+    
+    def test_log_priority_from_str(self):
+        log = logger.Logger()
+        assert log.log_priority_from_str('ERROR') == log.LOG_PRIORITY_ERROR
+        assert log.log_priority_from_str('INFO') == log.LOG_PRIORITY_INFO
+        assert log.log_priority_from_str('NOTICE') == log.LOG_PRIORITY_NOTICE
+        assert log.log_priority_from_str('WARN') == log.LOG_PRIORITY_WARNING
+        assert log.log_priority_from_str('DEBUG') == log.LOG_PRIORITY_DEBUG
+        assert log.log_priority_from_str('invalid') == log.LOG_PRIORITY_NOTICE
+        
+    def test_log_priority_to_str(self):
+        log = logger.Logger()
+        assert log.log_priority_to_str(log.LOG_PRIORITY_NOTICE) == 'NOTICE'
+        assert log.log_priority_to_str(log.LOG_PRIORITY_INFO) == 'INFO'
+        assert log.log_priority_to_str(log.LOG_PRIORITY_DEBUG) == 'DEBUG'
+        assert log.log_priority_to_str(log.LOG_PRIORITY_WARNING) == 'WARN'
+        assert log.log_priority_to_str(log.LOG_PRIORITY_ERROR) == 'ERROR'
+        assert log.log_priority_to_str(-1) == 'NOTICE'
+
+
+class TestSysLogger:
+    def test_basic(self):
+        log = syslogger.SysLogger()
+        log.logger.log = mock.MagicMock()
+        log.log_error('error message')
+        log.log_warning('warning message')
+        log.log_notice('notice message')
+        log.log_info('info message')
+        log.log_debug('debug message')
+        log.log(logging.ERROR, 'error msg', also_print_to_console=True)
+        
+    def test_log_priority(self):
+        log = syslogger.SysLogger()
+        log.set_min_log_priority(logging.ERROR)
+        assert log.logger.level == logging.ERROR
+        
+    def test_log_priority_from_str(self):
+        log = syslogger.SysLogger()
+        assert log.log_priority_from_str('ERROR') == logging.ERROR
+        assert log.log_priority_from_str('INFO') == logging.INFO
+        assert log.log_priority_from_str('NOTICE') == logging.NOTICE
+        assert log.log_priority_from_str('WARN') == logging.WARN
+        assert log.log_priority_from_str('DEBUG') == logging.DEBUG
+        assert log.log_priority_from_str('invalid') == logging.NOTICE
+        
+    def test_log_priority_to_str(self):
+        log = syslogger.SysLogger()
+        assert log.log_priority_to_str(logging.NOTICE) == 'NOTICE'
+        assert log.log_priority_to_str(logging.INFO) == 'INFO'
+        assert log.log_priority_to_str(logging.DEBUG) == 'DEBUG'
+        assert log.log_priority_to_str(logging.WARN) == 'WARN'
+        assert log.log_priority_to_str(logging.ERROR) == 'ERROR'
+        assert log.log_priority_to_str(-1) == 'NOTICE'
+
+
+class TestLoggerConfigHandler:
+    @mock.patch('sonic_py_common.logger_config_handler.redis.Redis', mock.MagicMock())
+    def test_start_stop(self):
+        log = logger.Logger()
+        log.config_handler.start()
+        log.config_handler.stop()
+  
+    @mock.patch('sonic_py_common.logger_config_handler.redis.Redis')
+    def test_reset(self, mock_redis, auto_stop):
+        mock_db = mock.MagicMock()
+        mock_redis.return_value = mock_db
+        mock_pubsub = mock.MagicMock()
+        mock_pubsub.get_message = mock.MagicMock(return_value=None)
+        mock_db.pubsub = mock.MagicMock(return_value=mock_pubsub)
+        log = logger.Logger(enable_config_thread=True)
+        old_thread = log.config_handler.log_config_thread
+        log.config_handler.reset()
+        assert old_thread != log.config_handler.log_config_thread
+        assert not log.config_handler.log_thread_started
+       
+    @mock.patch('sonic_py_common.logger_config_handler.redis.Redis') 
+    def test_run(self, mock_redis, auto_stop):
+        mock_db = mock.MagicMock()
+        mock_redis.return_value = mock_db
+        mock_db.hget = mock.MagicMock(return_value='ERROR')
+        mock_pubsub = mock.MagicMock()
+        mock_pubsub.get_message = mock.MagicMock(return_value=None)
+        mock_db.pubsub = mock.MagicMock(return_value=mock_pubsub)
+        log = logger.Logger(log_identifier='test', enable_config_thread=True)
+        slog = syslogger.SysLogger(log_identifier='test', enable_config_thread=True)
+        assert wait_until(lambda :log._min_log_priority == log.LOG_PRIORITY_ERROR,
+                          timeout=5,
+                          interval=1)
+        assert wait_until(lambda :slog.logger.level == logging.ERROR,
+                          timeout=5,
+                          interval=1)
+        mock_db.hget = mock.MagicMock(return_value='NOTICE')
+        mock_pubsub.get_message.return_value = {
+            'channel': '__keyspace@4__:LOGGER|test',
+            'data': 'hset'
+        }
+        assert wait_until(lambda :log._min_log_priority == log.LOG_PRIORITY_NOTICE,
+                          timeout=5,
+                          interval=1)
+        assert wait_until(lambda :slog.logger.level == logging.NOTICE,
+                          timeout=5,
+                          interval=1)
+        mock_pubsub.get_message.return_value = None
+   


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

SONiC provides two Python logger implementations: `sonic_py_common.logger.Logger` and `sonic_py_common.syslogger.SysLogger`. Both of them do not provide the ability to change log level at real time. Sometimes, in order to get more debug information, developer has to manually change the log level in code on a running switch and restart the Python daemon. This is not convenient.

SONiC also provides a C/C++ logger implementation in `sonic-platform-common.common.logger.cpp`. This C/C++ logger implementation is also a wrapper of Linux standard syslog which is widely used by swss/syncd. It provides the ability to set log level on fly by starting a thread to listen to CONFIG DB LOGGER table change. SONiC infrastructure also provides the Python wrapper for `sonic-platform-common.common.logger.cpp` which is `swsscommon.Logger`. However, this logger implementation also has some drawbacks:

- `swsscommon.Logger` assumes redis DB is ready to connect. This is a valid assumption for swss/syncd. But it is not good for a Python logger implementation because some Python script may be called before redis server starting.
- `swsscommon.Logger` wraps Linux syslog which only support single log identifier for a daemon.
So, `swsscommon.Logger` is not an option too.

This PR enhances `sonic_py_common.logger.Logger` and `sonic_py_common.syslogger.SysLogger` to allow user set log level at run time.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The PR introduces a logger configuration thread. This thread listens to redis LOGGER table change and set log level for each logger instance accordingly.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Full Unit test 
Manual test
Regression test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

