### PR TITLE
Do not mount redis.sock to avoid race condition

### DIFF
--- a/rules/docker-restapi.mk
+++ b/rules/docker-restapi.mk
@@ -28,7 +28,6 @@ endif
 
 $(DOCKER_RESTAPI)_CONTAINER_NAME = restapi
 $(DOCKER_RESTAPI)_RUN_OPT += -t
-$(DOCKER_RESTAPI)_RUN_OPT += -v /var/run/redis/redis.sock:/var/run/redis/redis.sock
 $(DOCKER_RESTAPI)_RUN_OPT += -v /etc/sonic/credentials:/etc/sonic/credentials:ro
 $(DOCKER_RESTAPI)_RUN_OPT += -p=8081:8081/tcp
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Service restapi is mounting /var/run/redis/redis.sock by command parameter "-v /var/run/redis/redis.sock:/var/run/redis/redis.sock". This is dangerous since it will create a directory named "/var/run/redis/redis.sock" if it does not exists. It could cause race condition like this:

1. restapi mount "/var/run/redis/redis.sock:/var/run/redis/redis.sock" and create a "/var/run/redis/redis.sock".

2 .redis server starts and try to bind to unix socket, but the folder already exists, so redis failed with log:

"""
Jun 20 22:52:08.451081 sonic INFO database#supervisord: redis 64:M 20 Jun 2024 22:52:08.442 # Opening Unix socket: bind: Address already in use
"""

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Since docker_image_ctl.j2 has already mounted /var/run/redis for all containers, there is no point and not safe to mount  /var/run/redis/redis.sock. So, I removed the mount from the make file.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

