### PR TITLE
[Mellanox] do not use system clock to avoid issues caused by system time change

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -447,7 +447,7 @@ class Chassis(ChassisBase):
         timeout = 1000.0 if timeout >= 1000 else float(timeout)
         port_dict = {}
         error_dict = {}
-        begin = time.time()
+        begin = time.monotonic()
         wait_ready_task = sfp.SFP.get_wait_ready_task()
         
         while True:        
@@ -524,7 +524,7 @@ class Chassis(ChassisBase):
                 }
             else:
                 if not wait_forever:
-                    elapse = time.time() - begin
+                    elapse = time.monotonic() - begin
                     if elapse * 1000 >= timeout:
                         return True, {'sfp': {}}
 
@@ -569,7 +569,7 @@ class Chassis(ChassisBase):
         timeout = 1000.0 if timeout >= 1000 else float(timeout)
         port_dict = {}
         error_dict = {}
-        begin = time.time()
+        begin = time.monotonic()
         
         while True:
             fds_events = self.poll_obj.poll(timeout)
@@ -619,7 +619,7 @@ class Chassis(ChassisBase):
                 }
             else:
                 if not wait_forever:
-                    elapse = time.time() - begin
+                    elapse = time.monotonic() - begin
                     if elapse * 1000 >= timeout:
                         return True, {'sfp': {}}
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -206,8 +206,8 @@ class DpuCtlPlat():
                     return True
                 poll_obj = poll()
                 poll_obj.register(dir_fd, POLLIN)
-                start = time.time()
-                while (time.time() - start) < WAIT_FOR_PCI_DEV:
+                start = time.monotonic()
+                while (time.monotonic() - start) < WAIT_FOR_PCI_DEV:
                     events = poll_obj.poll(WAIT_FOR_PCI_DEV * 1000)
                     if events:
                         if os.path.exists(os.path.dirname(self.get_pci_dev_path())):
@@ -473,9 +473,9 @@ class DpuCtlPlat():
     @contextmanager
     def time_check_context(self, msg):
         if self.verbosity:
-            start_time = time.time()
+            start_time = time.monotonic()
             yield
-            end_time = time.time()
+            end_time = time.monotonic()
             self.log_info(f"Total time taken = {end_time - start_time} for {msg}")
             return
         yield

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1475,14 +1475,14 @@ class SFP(NvidiaSFPCommon):
             # Resetting SFP requires a reloading of module firmware, it takes up to 3 seconds
             # according to standard
             max_wait_time = 3.5
-            begin = time.time()
+            begin = time.monotonic()
             while True:
                 ready_sfp_set = wait_ready_task.get_ready_set()
                 for sfp_index in ready_sfp_set:
                     s = sfp_list[sfp_index]
                     logger.log_debug(f'SFP {sfp_index} is recovered from resetting state')
                     s.on_event(EVENT_RESET_DONE)
-                elapse = time.time() - begin
+                elapse = time.monotonic() - begin
                 if elapse < max_wait_time:
                     time.sleep(0.5)
                 else:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -340,7 +340,7 @@ class Timer(threading.Thread):
         self.add_timer_event(timer_event, run_now)
 
     def add_timer_event(self, timer_event, run_now=True):
-        timestamp = time.time()
+        timestamp = time.monotonic()
         if not run_now:
             timestamp += timer_event.interval
 
@@ -356,7 +356,7 @@ class Timer(threading.Thread):
 
     def run(self):
         while not self._stop_event.is_set():
-            now = time.time()
+            now = time.monotonic()
             item = self._timestamp_queue.get()
             self._min_timestamp = item[0]
             if self._min_timestamp > now:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/wait_sfp_ready_task.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/wait_sfp_ready_task.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,7 +66,7 @@ class WaitSfpReadyTask(threading.Thread):
             is_empty = len(self._wait_dict) == 0
   
             # The item will be expired in 3 seconds
-            self._wait_dict[sfp_index] = time.time() + self.WAIT_TIME
+            self._wait_dict[sfp_index] = time.monotonic() + self.WAIT_TIME
 
         if is_empty:
             logger.log_debug('An item arrives, wake up WaitSfpReadyTask')
@@ -120,7 +121,7 @@ class WaitSfpReadyTask(threading.Thread):
                 self.event.wait()
                 self.event.clear()
 
-            now = time.time()
+            now = time.monotonic()
             with self.lock:
                 logger.log_debug(f'Processing wait SFP dict: {self._wait_dict}, now={now}')
                 for sfp_index, expire_time in self._wait_dict.items():

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -229,7 +230,7 @@ class WatchdogType1(WatchdogImplBase):
         # Save the watchdog arm timestamp
         # requiered for get_remaining_time()
         os.makedirs('/tmp/nvidia', exist_ok=True)
-        utils.write_file(self.TIMESTAMP_FILE, str(time.time()))
+        utils.write_file(self.TIMESTAMP_FILE, str(time.monotonic()))
 
         return ret
 
@@ -244,7 +245,7 @@ class WatchdogType1(WatchdogImplBase):
 
         if self.is_armed():
             arm_timestamp = utils.read_float_from_file(self.TIMESTAMP_FILE)
-            timeleft = int(self.timeout - (time.time() - arm_timestamp))
+            timeleft = int(self.timeout - (time.monotonic() - arm_timestamp))
 
         return timeleft
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +35,7 @@ from sonic_platform import sfp
 class TestChangeEvent:
     @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
     @mock.patch('select.poll')
-    @mock.patch('time.time')
+    @mock.patch('time.monotonic')
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
@@ -87,7 +88,7 @@ class TestChangeEvent:
     @mock.patch('sonic_platform.wait_sfp_ready_task.WaitSfpReadyTask.get_ready_set')    
     @mock.patch('sonic_platform.sfp.SFP.get_fd')
     @mock.patch('select.poll')
-    @mock.patch('time.time')
+    @mock.patch('time.monotonic')
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode', mock.MagicMock(return_value=True))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -461,7 +461,7 @@ class TestDpuClass:
             mock_time_diff.counter += 1
             return mock_time_diff.counter * timeout_val
         mock_time_diff.counter = 0
-        with patch("time.time", wraps=mock_time_diff):
+        with patch("time.monotonic", wraps=mock_time_diff):
             # PCI Device is not recognized
             assert not dpuctl_obj.wait_for_pci()
             pci_parent_path = os.path.dirname(pci_dev_path)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Mellanox platform API uses standard python time function `time.time()` in many places. `time.time()` gets time from system clock which could be changed by NTP or user. Adjusting system clock will affect the code logical and causes bugs. For example, in platform/mellanox/mlnx-platform-api/sonic_platform/utils.py there is a Timer class, the timer will trigger event with unexpected interval if user/NTP changes the system clock. This PR changes `time.time()` to `time.monotonic` to avoid such issue.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use `time.monotonic()` instead of `time.time` .

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Manual test.
Unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

