### PR TITLE
[Mellanox] set temperature file value to 0 when module is not present

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -142,7 +143,16 @@ class ThermalUpdater:
                 )
             else:
                 if pre_presence != presence:
-                    hw_management_independent_mode_update.thermal_data_clean_module(0, sfp.sdk_index + 1)
+                    # thermal control service requires to
+                    # set value 0 to all temperature files when module is not present
+                    hw_management_independent_mode_update.thermal_data_set_module(
+                        0,  # ASIC index always 0 for now
+                        sfp.sdk_index + 1,
+                        0,
+                        0,
+                        0,
+                        0
+                    )
 
             if pre_presence != presence:
                 self._sfp_status[sfp.sdk_index] = presence

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,5 +108,6 @@ class TestThermalUpdater:
         hw_management_independent_mode_update.thermal_data_set_module.assert_called_once_with(0, 11, 0, 0, 0, 0)
 
         mock_sfp.get_presence = mock.MagicMock(return_value=False)
+        hw_management_independent_mode_update.reset_mock()
         updater.update_module()
-        hw_management_independent_mode_update.thermal_data_clean_module.assert_called_once_with(0, 11)
+        hw_management_independent_mode_update.thermal_data_set_module.assert_called_once_with(0, 11, 0, 0, 0, 0)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Nvidia thermal control service requires to set temperature file value to 0 when module is not present 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Set temperature file value to 0 when module is not present 

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

unit test
manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

