### PR TITLE
[Mellanox] Optimize thermal updater performance

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -179,8 +179,6 @@ SFP_TYPE_SFF8636 = 'sff8636'
 # SFP stderr
 SFP_EEPROM_NOT_AVAILABLE = 'Input/output error'
 
-SFP_DEFAULT_TEMP_WARNNING_THRESHOLD = 70.0
-SFP_DEFAULT_TEMP_CRITICAL_THRESHOLD = 80.0
 SFP_TEMPERATURE_SCALE = 8.0
 
 # Module host management definitions begin
@@ -419,6 +417,9 @@ class SFP(NvidiaSFPCommon):
         else:
             self.state = STATE_FCP_DOWN
         self.processing_insert_event = False
+        self.sn = None
+        self.temp_high_threshold = None
+        self.temp_critical_threshold = None
 
     def __str__(self):
         return f'SFP {self.sdk_index}'
@@ -839,6 +840,67 @@ class SFP(NvidiaSFPCommon):
         except Exception as e:
             print(e)
         return [False] * api.NUM_CHANNELS if api else None
+    
+    def reinit_if_sn_changed(self):
+        """Reinitialize the SFP if the module ID has changed
+        """
+        sn = self.get_serial()
+        if sn != self.sn:
+            self.reinit()
+            self.sn = self.get_serial()
+            self.temp_high_threshold = None
+            self.temp_critical_threshold = None
+            return True
+        return False
+            
+    def get_temperature_info(self):
+        """Get SFP temperature info in a fast way. This function is faster than calling following functions one by one: get_temperature, get_temperature_warning_threshold, get_temperature_critical_threshold.
+
+        Returns:
+            tuple: (temperature, warning_threshold, critical_threshold)
+        """
+        try:
+            sn_changed = self.reinit_if_sn_changed()
+            if not self.is_sw_control():
+                # firmware control, read from sysfs
+                temp_file = f'/sys/module/sx_core/asic0/module{self.sdk_index}/temperature/input'
+                if not os.path.exists(temp_file):
+                    logger.log_error(f'Failed to read from file {temp_file} - not exists')
+                    temperature = None
+                else:
+                    temperature = utils.read_int_from_file(temp_file,
+                                                       log_func=None)
+                    temperature = temperature / SFP_TEMPERATURE_SCALE if temperature is not None else None
+            else:
+                # software control, read from EEPROM
+                temperature = super().get_temperature()
+            if temperature is None:
+                # Failed to read temperature, no need read threshold
+                return None, None, None
+            elif temperature == 0.0:
+                # Temperature is not supported, no need read threshold
+                return 0.0, 0.0, 0.0
+            else:
+                if not sn_changed and self.temp_high_threshold is not None and self.temp_critical_threshold is not None:
+                    return temperature, self.temp_high_threshold, self.temp_critical_threshold
+                else:
+                    # Read threshold from EEPROM
+                    api = self.get_xcvr_api()
+                    thresh_support = api.get_transceiver_thresholds_support()
+                    if thresh_support is None:
+                        # Failed to read threshold support field, no need read threshold
+                        return temperature, None, None
+                    if thresh_support:
+                        # Read threshold from EEPROM
+                        self.temp_high_threshold = api.xcvr_eeprom.read(consts.TEMP_HIGH_WARNING_FIELD)
+                        self.temp_critical_threshold = api.xcvr_eeprom.read(consts.TEMP_HIGH_ALARM_FIELD)
+                        return temperature, self.temp_high_threshold, self.temp_critical_threshold
+                    else:
+                        # No threshold support, use default threshold
+                        return temperature, 0.0, 0.0
+        except:
+            # module under initialization, return as temperature not supported
+            return 0.0, 0.0, 0.0
 
     def get_temperature(self):
         """Get SFP temperature
@@ -860,9 +922,8 @@ class SFP(NvidiaSFPCommon):
         except:
             return 0.0
 
-        self.reinit()
-        temperature = super().get_temperature()
-        return temperature if temperature is not None else None
+        self.reinit_if_sn_changed()
+        return super().get_temperature()
 
     def get_temperature_warning_threshold(self):
         """Get temperature warning threshold
@@ -877,14 +938,8 @@ class SFP(NvidiaSFPCommon):
         except:
             return 0.0
         
-        support, thresh = self._get_temperature_threshold()
-        if support is None or thresh is None:
-            # Failed to read from EEPROM
-            return None
-        if support is False:
-            # Do not support
-            return 0.0
-        return thresh.get(consts.TEMP_HIGH_WARNING_FIELD, SFP_DEFAULT_TEMP_WARNNING_THRESHOLD)
+        self.temp_high_threshold = self._get_temperature_threshold(consts.TEMP_HIGH_WARNING_FIELD)
+        return self.temp_high_threshold
 
     def get_temperature_critical_threshold(self):
         """Get temperature critical threshold
@@ -899,33 +954,32 @@ class SFP(NvidiaSFPCommon):
         except:
             return 0.0
 
-        support, thresh = self._get_temperature_threshold()
-        if support is None or thresh is None:
-            # Failed to read from EEPROM
-            return None
-        if support is False:
-            # Do not support
-            return 0.0
-        return thresh.get(consts.TEMP_HIGH_ALARM_FIELD, SFP_DEFAULT_TEMP_CRITICAL_THRESHOLD)
+        self.temp_critical_threshold = self._get_temperature_threshold(consts.TEMP_HIGH_ALARM_FIELD)
+        return self.temp_critical_threshold
 
-    def _get_temperature_threshold(self):
+    def _get_temperature_threshold(self, thresh_field):
         """Get temperature thresholds data from EEPROM
+        
+        Args:
+            thresh_field (str): threshold field name
 
         Returns:
-            tuple: (support, thresh_dict)
+            float: temperature threshold
         """
-        self.reinit()
+        sn_changed = self.reinit_if_sn_changed()
+        if not sn_changed:
+            if thresh_field == consts.TEMP_HIGH_WARNING_FIELD and self.temp_high_threshold is not None:
+                return self.temp_high_threshold
+            elif thresh_field == consts.TEMP_HIGH_ALARM_FIELD and self.temp_critical_threshold is not None:
+                return self.temp_critical_threshold
         api = self.get_xcvr_api()
         if not api:
-            return None, None
+            return None
 
         thresh_support = api.get_transceiver_thresholds_support()
-        if thresh_support:
-            if isinstance(api, sff8636.Sff8636Api) or isinstance(api, sff8436.Sff8436Api):
-                return thresh_support, api.xcvr_eeprom.read(consts.TEMP_THRESHOLDS_FIELD)
-            return thresh_support, api.xcvr_eeprom.read(consts.THRESHOLDS_FIELD)
-        else:
-            return thresh_support, {}
+        if thresh_support is None:
+            return None
+        return api.xcvr_eeprom.read(thresh_field) if thresh_support else 0.0
 
     def get_xcvr_api(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -120,18 +120,11 @@ class ThermalUpdater:
             presence = sfp.get_presence()
             pre_presence = self._sfp_status.get(sfp.sdk_index)
             if presence:
-                temperature = sfp.get_temperature()
-                if temperature == 0:
-                    warning_thresh = 0
-                    critical_thresh = 0
-                    fault = 0
-                else:
-                    warning_thresh = sfp.get_temperature_warning_threshold()
-                    critical_thresh = sfp.get_temperature_critical_threshold()
-                    fault = ERROR_READ_THERMAL_DATA if (temperature is None or warning_thresh is None or critical_thresh is None) else 0
-                    temperature = 0 if temperature is None else temperature * SFP_TEMPERATURE_SCALE
-                    warning_thresh = 0 if warning_thresh is None else warning_thresh * SFP_TEMPERATURE_SCALE
-                    critical_thresh = 0 if critical_thresh is None else critical_thresh * SFP_TEMPERATURE_SCALE
+                temperature, warning_thresh, critical_thresh = sfp.get_temperature_info()
+                fault = ERROR_READ_THERMAL_DATA if (temperature is None or warning_thresh is None or critical_thresh is None) else 0
+                temperature = 0 if temperature is None else temperature * SFP_TEMPERATURE_SCALE
+                warning_thresh = 0 if warning_thresh is None else warning_thresh * SFP_TEMPERATURE_SCALE
+                critical_thresh = 0 if critical_thresh is None else critical_thresh * SFP_TEMPERATURE_SCALE
 
                 hw_management_independent_mode_update.thermal_data_set_module(
                     0, # ASIC index always 0 for now

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -95,14 +95,12 @@ class TestThermalUpdater:
         mock_sfp = mock.MagicMock()
         mock_sfp.sdk_index = 10
         mock_sfp.get_presence = mock.MagicMock(return_value=True)
-        mock_sfp.get_temperature = mock.MagicMock(return_value=55.0)
-        mock_sfp.get_temperature_warning_threshold = mock.MagicMock(return_value=70.0)
-        mock_sfp.get_temperature_critical_threshold = mock.MagicMock(return_value=80.0)
+        mock_sfp.get_temperature_info = mock.MagicMock(return_value=(55.0, 70.0, 80.0))
         updater = ThermalUpdater([mock_sfp])
         updater.update_module()
         hw_management_independent_mode_update.thermal_data_set_module.assert_called_once_with(0, 11, 55000, 80000, 70000, 0)
 
-        mock_sfp.get_temperature = mock.MagicMock(return_value=0.0)
+        mock_sfp.get_temperature_info = mock.MagicMock(return_value=(0.0, 0.0, 0.0))
         hw_management_independent_mode_update.reset_mock()
         updater.update_module()
         hw_management_independent_mode_update.thermal_data_set_module.assert_called_once_with(0, 11, 0, 0, 0, 0)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

